### PR TITLE
Update utility.cc

### DIFF
--- a/matrix/utility.cc
+++ b/matrix/utility.cc
@@ -442,6 +442,8 @@ HermitianEigenvalues(const Matrix& re, const Matrix& im,
 
     }
 
+#ifdef I
+#undef I
 
 #include <complex>
 #include <vector>
@@ -2681,4 +2683,5 @@ void SVDcomplex(const Matrix& Mre, const Matrix& Mim, Matrix& Ure,
     Vim = -V.ImMat().t();
     }
 
+#endif
 


### PR DESCRIPTION
Fixed error: expected unqualified-id before ‘**extension**’
 static Complex I(0.0,1.0), C1(1.0,0.0),C0(0.0,0.0);
                ^
utility.cc:453:16: error: expected ‘)’ before ‘**extension**’
with PLATFORM=lapack
