### PR TITLE
Added missing standard library includes for gcc 4.8

### DIFF
--- a/itensor/global.h
+++ b/itensor/global.h
@@ -16,6 +16,7 @@
 #include "cppversion.h"
 #include "print.h"
 #include <ctime>
+#include <string.h>
 
 namespace itensor {
 

--- a/itensor/iqtdat.h
+++ b/itensor/iqtdat.h
@@ -5,6 +5,7 @@
 #ifndef __ITENSOR_IQTDAT_H
 #define __ITENSOR_IQTDAT_H
 #include "indexset.h"
+#include <algorithm>
 
 namespace itensor {
 

--- a/utilities/cppversion.h
+++ b/utilities/cppversion.h
@@ -5,15 +5,15 @@
 
 #define Foreach(X,Y) for(X : Y)
 
-#include <array>
+#include <memory>
 namespace itensor {
-using std::array;
 using std::shared_ptr;
 using std::make_shared;
 };
 
-#include <memory>
+#include <array>
 namespace itensor {
+using std::array;
 using std::shared_ptr;
 using std::make_shared;
 };


### PR DESCRIPTION
I got away with switching the order of <memory> and <array> in cppversion.h and adding <algorithm> at only one point. This works for gcc 4.8.2 with ACML
