### PR TITLE
CMakeLists update - correct inclusion and installation of headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,9 @@ list(APPEND CMAKE_LINKER_FLAGS ${LAPACK_LINKER_FLAGS})
 link_libraries(${LAPACK_LIBRARIES})
 
 # build itensor parts
+add_subdirectory(utilities)
 add_subdirectory(matrix)
 add_subdirectory(itensor)
-add_subdirectory(utilities)
 
 # Enable testing
 option(Testing "Enable testing" ON)

--- a/itensor/CMakeLists.txt
+++ b/itensor/CMakeLists.txt
@@ -26,10 +26,10 @@ set (SOURCES
     tevol.cc
     )
 
-include_directories(../include .)
+include_directories(../utilities ../matrix .)
 
 add_library(itensor STATIC ${SOURCES})
 install(TARGETS itensor DESTINATION lib)
-
+install(FILES ${HEADERS} DESTINATION include/itensor)
 
 

--- a/matrix/CMakeLists.txt
+++ b/matrix/CMakeLists.txt
@@ -7,7 +7,8 @@ set (SOURCES matrix.cc utility.cc sparse.cc david.cc hpsortir.cc
 	conjugate_gradient.cc sparseref.cc
 	daxpy.cc svd.cc)
 
-include_directories(../include .)
+include_directories(../utilities .)
 add_library(matrix STATIC ${SOURCES})
 install(TARGETS matrix DESTINATION lib)
+install(FILES ${HEADERS} DESTINATION include/itensor)
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(../include)
+include_directories(../utilities ../matrix ../itensor)
 
 set (progs 
 dmrg iqdmrg dmrg_table dmrgj1j2 exthubbard idmrg

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+include_directories(../utilities ../matrix ../itensor)
 add_subdirectory(01_one_site)
 add_subdirectory(02_two_site)
 add_subdirectory(03_svd)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -23,7 +23,7 @@ set (tests
     safebool_test.cc
 )
 
-include_directories(../include .)
+include_directories(../utilities ../matrix ../itensor)
 
 add_executable(test1 ${tests})
 target_link_libraries(test1 utility matrix itensor) 

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -8,9 +8,9 @@ set (SOURCES error.cc ran1.cc
     )
 #file(GLOB SOURCES "*.cc")
 
-include_directories(../include .)
+include_directories(.)
 add_library(utility STATIC ${SOURCES})
 
 install(TARGETS utility DESTINATION lib)
-
+install(FILES ${HEADERS} DESTINATION include/itensor)
 


### PR DESCRIPTION
Here's a fix for the header inclusion. It doesn't copy headers to "include" directory but rather includes utilities, matrix and itensor directories. In the end the headers get installed to ${CMAKE_INSTALL_PREFIX}/include/itensor . 
