### PR TITLE
Fixed paths in CMake files; added option to build static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 2.8)
 project (ITensor)
 
+option(BUILD_STATIC "Build static libraries" OFF)
+
 # Disable build in source (not to overlap with existing Makefile)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)

--- a/itensor/CMakeLists.txt
+++ b/itensor/CMakeLists.txt
@@ -1,16 +1,15 @@
-set (HEADERS tinyformat.h print.h global.h real.h permutation.h index.h 
+set (HEADERS global.h real.h permutation.h index.h 
         indexset.h counter.h itensor.h qn.h iqindex.h iqtdat.h iqtensor.h 
         condenser.h combiner.h qcounter.h iqcombiner.h 
         spectrum.h svdalgs.h mps.h mpo.h core.h observer.h DMRGObserver.h 
         sweeps.h stats.h siteset.h
-        hams/HubbardChain.h hams/Heisenberg.h hams/ExtendedHubbard.h 
-        hams/TriHeisenberg.h hams/Ising.h hams/J1J2Chain.h 
-        hams/tJChain.h 
-        sites/spinhalf.h sites/spinone.h sites/hubbard.h sites/spinless.h
-        sites/tj.h sites/Z3.h
         eigensolver.h localop.h localmpo.h localmposet.h 
         partition.h hambuilder.h localmpo_mps.h tevol.h dmrg.h bondgate.h
         integrators.h idmrg.h TEvolObserver.h iterpair.h )
+
+set (DIRECTORIES 
+	sites
+	hams)
 
 set (SOURCES 
     index.cc 
@@ -27,9 +26,14 @@ set (SOURCES
     )
 
 include_directories(../utilities ../matrix .)
-
-add_library(itensor STATIC ${SOURCES})
+add_library(itensor SHARED ${SOURCES} $<TARGET_OBJECTS:matrix>
+	$<TARGET_OBJECTS:utility>)
 install(TARGETS itensor DESTINATION lib)
+if (BUILD_STATIC)
+	add_library(itensor_static STATIC ${SOURCES} $<TARGET_OBJECTS:matrix>
+		$<TARGET_OBJECTS:utility>)
+	install(TARGETS itensor_static DESTINATION lib)
+endif (BUILD_STATIC)
+
 install(FILES ${HEADERS} DESTINATION include/itensor)
-
-
+install(DIRECTORY ${DIRECTORIES} DESTINATION include/itensor)

--- a/matrix/CMakeLists.txt
+++ b/matrix/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set (HEADERS matrixref.h matrix.h sparse.h bigmatrix.h davidson.h
+set (HEADERS matrixref.h matrix.h sparse.h bigmatrix.h davidson.h svd.h
 	storelink.h conjugate_gradient.h sparseref.h)
 
 set (SOURCES matrix.cc utility.cc sparse.cc david.cc hpsortir.cc 
@@ -8,7 +8,7 @@ set (SOURCES matrix.cc utility.cc sparse.cc david.cc hpsortir.cc
 	daxpy.cc svd.cc)
 
 include_directories(../utilities .)
-add_library(matrix STATIC ${SOURCES})
-install(TARGETS matrix DESTINATION lib)
+add_library(matrix OBJECT ${SOURCES})
+set_property(TARGET matrix PROPERTY POSITION_INDEPENDENT_CODE 1)
 install(FILES ${HEADERS} DESTINATION include/itensor)
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -6,5 +6,5 @@ dmrg iqdmrg dmrg_table dmrgj1j2 exthubbard idmrg
 
 foreach(prog ${progs})
     add_executable(${prog}-sample "${prog}.cc")
-    target_link_libraries(${prog}-sample utility itensor matrix)
+    target_link_libraries(${prog}-sample itensor)
 endforeach()

--- a/tutorial/01_one_site/CMakeLists.txt
+++ b/tutorial/01_one_site/CMakeLists.txt
@@ -1,4 +1,4 @@
 include_directories(../../include)
 set(tutorial one)
 add_executable(${tutorial} ${tutorial}.cc)
-target_link_libraries(${tutorial} utility itensor matrix)
+target_link_libraries(${tutorial} itensor)

--- a/tutorial/02_two_site/CMakeLists.txt
+++ b/tutorial/02_two_site/CMakeLists.txt
@@ -1,4 +1,4 @@
 include_directories(../../include)
 set(tutorial two)
 add_executable(${tutorial} ${tutorial}.cc)
-target_link_libraries(${tutorial} utility itensor matrix)
+target_link_libraries(${tutorial} itensor)

--- a/tutorial/03_svd/CMakeLists.txt
+++ b/tutorial/03_svd/CMakeLists.txt
@@ -1,4 +1,4 @@
 include_directories(../../include)
 set(tutorial svd)
 add_executable(${tutorial} ${tutorial}.cc)
-target_link_libraries(${tutorial} utility itensor matrix)
+target_link_libraries(${tutorial} itensor)

--- a/tutorial/04_mps/CMakeLists.txt
+++ b/tutorial/04_mps/CMakeLists.txt
@@ -1,4 +1,4 @@
 include_directories(../../include)
 set(tutorial j1j2)
 add_executable(${tutorial} ${tutorial}.cc)
-target_link_libraries(${tutorial} utility itensor matrix)
+target_link_libraries(${tutorial} itensor)

--- a/tutorial/05_gates/CMakeLists.txt
+++ b/tutorial/05_gates/CMakeLists.txt
@@ -1,4 +1,4 @@
 include_directories(../../include)
 set(tutorial gates)
 add_executable(${tutorial} ${tutorial}.cc)
-target_link_libraries(${tutorial} utility itensor matrix)
+target_link_libraries(${tutorial} itensor)

--- a/tutorial/06_DMRG/CMakeLists.txt
+++ b/tutorial/06_DMRG/CMakeLists.txt
@@ -1,4 +1,4 @@
 include_directories(../../include)
 set(tutorial dmrg)
 add_executable(${tutorial} ${tutorial}.cc)
-target_link_libraries(${tutorial} utility itensor matrix)
+target_link_libraries(${tutorial} itensor)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -26,7 +26,7 @@ set (tests
 include_directories(../utilities ../matrix ../itensor)
 
 add_executable(test1 ${tests})
-target_link_libraries(test1 utility matrix itensor) 
+target_link_libraries(test1 itensor) 
 add_test(test1 test1)
 
 

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -1,5 +1,5 @@
 set (HEADERS 
-    cppversion.h indent.h cputime.h tarray1.h 
+    cppversion.h indent.h cputime.h tarray1.h tinyformat.h print.h
     flstring.h option.h input.h error.h minmax.h safebool.h
     )
 
@@ -9,8 +9,8 @@ set (SOURCES error.cc ran1.cc
 #file(GLOB SOURCES "*.cc")
 
 include_directories(.)
-add_library(utility STATIC ${SOURCES})
+add_library(utility OBJECT ${SOURCES})
+set_property(TARGET utility PROPERTY POSITION_INDEPENDENT_CODE 1)
 
-install(TARGETS utility DESTINATION lib)
 install(FILES ${HEADERS} DESTINATION include/itensor)
 


### PR DESCRIPTION
Instead of installing 3 static libraries (libraries with quite common name like libmatrix/libutility inside /usr/lib might be confusing!), build single shared library libitensor.so and add a CMake property to build a static library libitensor_static.a.
This also fixes some paths for headers (e.g it was looking for non-existent tinyformat.h inside itensor/ directory while it was moved to utilities/)