### PR TITLE
Changes for MSVC compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,14 @@ else()
  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  if ("${CMAKE_CL_64}")
+    add_definitions(-D__x86_64=1)
+  else ()
+    add_definitions(-Di386=1)
+  endif()
+endif ()
+
 option (CXX11 OFF)
 if (CXX11) 
     # enable C++11 

--- a/utilities/cputime.cc
+++ b/utilities/cputime.cc
@@ -4,8 +4,6 @@
 //
 
 #include "cputime.h"
-#include <sys/time.h>
-#include <sys/resource.h>
 #include <string>
 #include <sstream>
 #include <iomanip>
@@ -14,12 +12,35 @@
 using namespace std;
 using namespace std::chrono;
 
+#if defined(_MSC_VER)
+#include <windows.h>
+
+double cpu_mytime()
+    {
+    FILETIME ftCreation, ftExit, ftKernel, ftUser;
+    SYSTEMTIME stUser;
+
+    HANDLE hProcess = GetCurrentProcess();
+    if (GetProcessTimes(hProcess, &ftCreation, &ftExit, &ftKernel, &ftUser) != -1) 
+        {
+        if (FileTimeToSystemTime(&ftUser, &stUser) != -1)
+            {
+            return stUser.wHour * 3600.0 + stUser.wMinute * 60.0 + stUser.wSecond + stUser.wMilliseconds * 1E-3;
+            }
+        }
+    return 0.0;
+    }
+#else
+#include <sys/time.h>
+#include <sys/resource.h>
+
 double cpu_mytime()		// cpu time in seconds used by program
     {
     struct rusage result;
     getrusage(RUSAGE_SELF,&result);
     return result.ru_utime.tv_sec + 1e-6 * result.ru_utime.tv_usec;
     }
+#endif
 
 double cpu_mywall()		// wall time since program started
     {


### PR DESCRIPTION
I confirmed , with these changes ITensor can be compiled with cmake + MSVC + MKL using the following command

```
cmake.exe E:\dev\src\ITensor -G "Visual Studio 12 2013 Win64" -DSample=OFF -DTutorial=OFF -DTesting=OFF -DBLA_VENDOR=Intel
```