### PR TITLE
change static const in namespace scope to const

### DIFF
--- a/itensor/global.h
+++ b/itensor/global.h
@@ -38,15 +38,15 @@ namespace itensor {
 
 enum Direction { Fromright, Fromleft, Both, None };
 
-static const int NMAX = 8;
-static const Real MIN_CUT = 1E-15;
-static const int MAX_M = 5000;
+const int NMAX = 8;
+const Real MIN_CUT = 1E-15;
+const int MAX_M = 5000;
 
 
-static const Cplx Complex_1 = Cplx(1,0);
-static const Cplx Complex_i = Cplx(0,1);
-static const Cplx Cplx_1 = Cplx(1,0);
-static const Cplx Cplx_i = Cplx(0,1);
+const Cplx Complex_1 = Cplx(1,0);
+const Cplx Complex_i = Cplx(0,1);
+const Cplx Cplx_1 = Cplx(1,0);
+const Cplx Cplx_i = Cplx(0,1);
 
 // The PAUSE macro is useful for debugging. 
 // Prints the current line number and pauses

--- a/itensor/mps/mpo.h
+++ b/itensor/mps/mpo.h
@@ -10,7 +10,7 @@
 
 namespace itensor {
 
-static const Real DefaultLogRefScale(2.0255);
+const Real DefaultLogRefScale(2.0255);
 
 template<class Tensor> class MPOt;
 

--- a/itensor/real.h
+++ b/itensor/real.h
@@ -19,16 +19,16 @@ namespace itensor {
 
 //Real ran1();
 
-static const Real Pi = 3.1415926535897932384626433832795028841971693993;
-static const Real Sqrt2 = sqrt(2);
-static const Real ISqrt2 = 1.0/sqrt(2);
+const Real Pi = 3.1415926535897932384626433832795028841971693993;
+const Real Sqrt2 = sqrt(2);
+const Real ISqrt2 = 1.0/sqrt(2);
 //static const Real Sqrt3 = sqrt(3);
 //static const Real ISqrt3 = 1.0/sqrt(3);
 
 template <typename T>
 T sqr(T x) { return x*x; }
 
-static const Real ApproxReal_Accuracy = 1E-12;
+const Real ApproxReal_Accuracy = 1E-12;
 
 struct ApproxReal
     {
@@ -62,9 +62,9 @@ struct ApproxReal
 
     };
 
-static const Real maxlogdouble = log(std::numeric_limits<double>::max());
+const Real maxlogdouble = log(std::numeric_limits<double>::max());
 
-static const Real LogNumber_Accuracy = 1E-12;
+const Real LogNumber_Accuracy = 1E-12;
 
 class TooBigForReal : public ITError
     {


### PR DESCRIPTION
Static in namespace scope is superfluous. So I change "static const" to "const" in 
* global.h
* mpo.h
* real.h  