### PR TITLE
fix a const error in IndexSetIter::operator+()

### DIFF
--- a/itensor/indexset.h
+++ b/itensor/indexset.h
@@ -507,7 +507,7 @@ operator-(const IndexSetIter<T>& x, const IndexSetIter<T>& y)
 
 template <typename T>
 IndexSetIter<T> 
-operator+(const IndexSetIter<T>& x, typename IndexSetIter<T>::difference_type d) 
+operator+(IndexSetIter<T>& x, typename IndexSetIter<T>::difference_type d) 
     { 
     return x += d;
     } 


### PR DESCRIPTION
 There exists an const error in the IndexSetIter::operator+(), which affect the following codes.

` Index s1=Index("s1",4),s2=Index("s2",6);
 auto b=delta(s1,s2);
 auto c=b.inds().begin();
 PrintData(*c);
 PrintData(*(c+1));`

where the += operator in the diffinition of operaotr+() actually modifies the value of x.
The IndexSetIter::operator-() may also occurs this const error, but I haven't test it.
