### PR TITLE
bring toIQMPO, toIQ back to work

### DIFF
--- a/itensor/mps/mpo.h
+++ b/itensor/mps/mpo.h
@@ -68,8 +68,8 @@ class MPOt : private MPSt<Tensor>
     MPOt<ITensor>
     toMPO() const;
 
-    //MPOt<IQTensor>
-    //toIQMPO() const;
+    MPOt<IQTensor>
+    toIQMPO() const;
 
     //MPOt: index methods --------------------------------------------------
 
@@ -132,12 +132,12 @@ class MPOt : private MPSt<Tensor>
     //use isComplex(W) instead
     using Parent::isComplex;
 
-    //void 
-    //toIQ(QN totalq, MPOt<IQTensor>& res, Real cut = 1E-12) const
-    //    {
-    //    res = MPOt<IQTensor>(*sites_,logrefNorm_);
-    //    convertToIQ(*sites_,A_,res.A_,totalq,cut);
-    //    }
+    void 
+    toIQ(QN totalq, IQMPO& res, Real cut = 1E-12) const
+        {
+        res = IQMPO(*sites_,logrefNorm_);
+        convertToIQ(*sites_,A_,res.A_,totalq,cut);
+        }
 
     }; //class MPOt<Tensor>
 

--- a/itensor/mps/mpo.ih
+++ b/itensor/mps/mpo.ih
@@ -30,6 +30,25 @@ toMPO() const
     return MPO();
     }
 
+template <> inline
+IQMPO MPO::
+toIQMPO() const
+    {
+    IQMPO res(*sites_,logrefNorm_);
+    convertToIQ(*sites_,A_,res.A_);
+    return res;
+    }
+
+//toMPO method fails unless template class 
+//Tensor is set to IQTensor (object is an IQMPO)
+template<class Tensor>
+IQMPO MPOt<Tensor>::
+toIQMPO() const
+    {
+    Error("toIQMPO only implemented for class MPO");
+    return IQMPO();
+    }
+
 template<typename T>
 bool
 isComplex(MPOt<T> const& W)

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -1239,300 +1239,310 @@ checkRange(int i) const
     }
 
 //Auxilary method for convertToIQ
-long 
+long
 collapseCols(const Vector& Diag, Matrix& M)
-    {
-    long nr = Diag.size(), 
-         nc = long(sumels(Diag));
+{
+    long nr = Diag.size(),
+            nc = long(sumels(Diag));
     assert(nr != 0);
     if(nc == 0) return nc;
     M = Matrix(nr,nc);
     long c = 0;
-    for(long r = 1; r <= nr; ++r)
-        if(Diag(r) == 1) { M(r,++c) = 1; }
+    for(long r = 0; r < nr; ++r)
+        if(Diag(r) == 1) { M(r,c) = 1; ++c;}
     return nc;
-    }
+}
 
-int 
+int
 periodicWrap(int j, int N)
-    {
+{
     if(j < 1)
         while(j < 1) j += N;
     else
     if(j > N)
         while(j > N) j -= N;
     return j;
+}
+
+void
+convertToIQ(const SiteSet& sites, const vector<ITensor>& A,
+             vector<IQTensor>& qA, QN totalq, Real cut)
+{
+    const int N = sites.N();
+    qA.resize(A.size());
+    const bool is_mpo = hasindex(A[1],sites.siP(1));
+    const int Dim = sites.si(1).m();
+    if(sites.si(2).m() != Dim)
+        Error("convertToIQ assumes uniform site dimension");
+    const int PDim = (is_mpo ? Dim : 1);
+
+    // If MPO, set all tensors to identity ops initially
+    if(is_mpo)
+    {
+        for(int j = 1; j <= N; ++j)
+            qA.at(j) = sites.op("Id",j);
     }
 
-//void 
-//convertToIQ(const SiteSet& sites, const vector<ITensor>& A, 
-//            vector<IQTensor>& qA, QN totalq, Real cut)
-//    {
-//    const int N = sites.N();
-//    qA.resize(A.size());
-//    const bool is_mpo = hasindex(A[1],sites.siP(1));
-//    const int Dim = sites.si(1).m();
-//    if(sites.si(2).m() != Dim)
-//        Error("convertToIQ assumes uniform site dimension");
-//    const int PDim = (is_mpo ? Dim : 1);
-//
-//    // If MPO, set all tensors to identity ops initially
-//    if(is_mpo)
-//        {
-//        for(int j = 1; j <= N; ++j)
-//            qA.at(j) = sites.op("Id",j);
-//        }
-//
-//    const int fullrank = (is_mpo ? 4 : 3);
-//    int start = 1, end = N;
-//
-//    for(int j = 1; j <= N; ++j)
-//        if(A[j].r() == fullrank)
-//            if(A.at(periodicWrap(j-1,N)).r() < fullrank) 
-//                {
-//                start = periodicWrap(j-1,N);
-//                //cout << "Got start at " << start << "\n";
-//                break;
-//                }
-//
-//    for(int j = 1; j <= N; ++j)
-//        if(A[j].r() == fullrank)
-//            if(A.at(periodicWrap(j+1,N)).r() < fullrank) 
-//                {
-//                end = periodicWrap(j+1,N);
-//                //cout << "Got end at " << end << "\n";
-//                break;
-//                }
-//
-//    //cout << "Converting to IQ with (start, end) = " << start SP end << endl;
-//
-//    vector<IQIndex> linkind(N+1);
-//
-//    map<QN,Vector> qD; //Diags of compressor matrices by QN
-//
-//    using qt_vt = map<QN,vector<ITensor> >::value_type;
-//    map<QN,vector<ITensor> > qt; //ITensor blocks by QN
-//
-//    using qC_vt = map<QN,ITensor>::value_type;
-//    map<QN,ITensor> qC; //Compressor ITensors by QN
-//
-//    ITensor block;
-//    vector<ITensor> nblock;
-//    vector<IndexQN> iq;
-//
-//    QN q;
-//
-//    qC[totalq] = ITensor(); //Represents Virtual index
-//    //First value of prev_q below set to totalq
-//
-//    const int show_s = 0;
-//
-//    Index bond, prev_bond;
-//    int Send = (end < start ? N+end : end); 
-//    for(int S = start; S <= Send; ++S)
-//        {
-//        int s = periodicWrap(S,N);
-//        int sprev = periodicWrap(S-1,N);
-//        int snext = periodicWrap(S+1,N);
-//
-//        qD.clear(); 
-//        qt.clear();
-//
-//        if(S > start) prev_bond = commonIndex(A[sprev],A[s],Link);
-//        if(S < Send) bond = commonIndex(A[s],A[snext],Link);
-//
-//        if(s == show_s) { PrintData(A[s]); }
-//
-//        for(const qC_vt& x : qC) 
-//        for(int n = 1; n <= Dim;  ++n)
-//        for(int u = 1; u <= PDim; ++u)
-//            {
-//            //Each compressor represents a particular
-//            //QN channel given by prev_q
-//            const QN& prev_q = x.first; 
-//            //Alias previous compressor ITensor to comp
-//            const ITensor& comp = x.second; 
-//
-//            q = (is_mpo ? prev_q+sites.si(s).qn(n)-sites.si(s).qn(u) 
-//                        : prev_q-sites.si(s).qn(n));
-//
-//            //For the last site, only keep blocks 
-//            //compatible with specified totalq i.e. q=0 here
-//            if(S == Send && q != QN()) continue;
-//
-//            //Set Site indices of A[s] and its previous Link Index
-//            block = A[s];
-//            if(S != start) block *= dag(comp);
-//            block *= Index(sites.si(s))(n);
-//            if(is_mpo) block *= Index(sites.siP(s))(u);
-//
-//            //Initialize D Vector (D records which values of
-//            //the right Link Index to keep for the current QN q)
-//            auto count = qD.count(q);
-//            Vector& D = qD[q];
-//            if(count == 0) 
-//                { 
-//                D.resize(bond.m()); 
-//                for(auto& el : D) el = 0; 
-//                }
-//
-//            if(s == show_s)
-//                {
-//                println("For n = ",n);
-//                printfln("Got a block with norm %.10f",norm(block));
-//                println("bond.m() = ",bond.m());
-//                PrintData(block);
-//                if(s != 1) PrintData(comp);
-//                }
-//
-//            bool keep_block = false;
-//            if(S == Send) 
-//                { keep_block = true; }
-//            else
-//                {
-//                if(bond.m() == 1 && norm(block) != 0) 
-//                    { 
-//                    for(auto& el : D) el = 1; 
-//                    keep_block = true; 
-//                    }
-//                else
-//                    {
-//                    ITensor summed_block;
-//                    if(S==start) 
-//                        { summed_block = block; }
-//                    else
-//                        {
-//                        //Here we sum over the previous link index
-//                        //which is already ok, analyze the one to the right
-//                        assert(comp.r()==2);
-//                        auto ci = comp.inds().begin();
-//                        const Index& new_ind = (*ci==prev_bond ? *(ci+1) : *ci);
-//                        summed_block = diag(1,new_ind) * block;
-//                        }
-//                    //summed_block.print("summed_block");
-//
-//                    Real rel_cut = -1;
-//                    const ITensor& sb = summed_block;
-//                    for(int j = 1; j <= bond.m(); ++j)
-//                        { rel_cut = std::max(std::fabs(sb.real(bond(j))),rel_cut); }
-//                    assert(rel_cut >= 0);
-//                    //Real rel_cut = summed_block.norm()/summed_block.vecSize();
-//                    rel_cut *= cut;
-//                    //cout << "rel_cut == " << rel_cut << "\n";
-//
-//                    if(rel_cut > 0)
-//                    for(int j = 1; j <= bond.m(); ++j)
-//                        {
-//                        if(std::fabs(sb.real(bond(j))) > rel_cut) 
-//                            { 
-//                            D(j) = 1; 
-//                            keep_block = true; 
-//                            }
-//                        }
-//                    }
-//                } //else (S != Send)
-//
-//            if(keep_block)
-//                {
-//                qD[q] = D;
-//
-//                IndexSet newinds(block.inds());
-//                if(is_mpo) 
-//                    {
-//                    newinds.addindex(dag(sites.si(s)(n).indexqn()));
-//                    newinds.addindex(sites.siP(s)(u).indexqn());
-//                    }
-//                else 
-//                    { 
-//                    newinds.addindex(sites.si(s)(n).indexqn()); 
-//                    }
-//
-//                if(s==show_s)
-//                    {
-//                    PrintData(block);
-//                    cout << "D = " << D << "\n";
-//                    }
-//
-//                qt[q].push_back(ITensor(std::move(newinds),std::move(block.store())));
-//
-//                }
-//            }
-//
-//        qC.clear();
-//
-//        for(const qt_vt& x : qt)
-//            {
-//            const vector<ITensor>& blks = x.second;
-//            if(blks.size() != 0)
-//                {
-//                q = x.first; 
-//                if(S == Send) 
-//                    { for(const ITensor& t : blks) nblock.push_back(t); }
-//                else
-//                    {
-//                    Matrix M; 
-//                    auto mm = collapseCols(qD[q],M);
-//                    if(s==show_s)
-//                        {
-//                        println("Adding block, mm = ",mm);
-//                        Print(q);
-//                        cout << "qD[q] = " << qD[q] << "\n";
-//                        cout << "M = \n" << M << "\n";
-//                        int count = 0;
-//                        for(const ITensor& t : blks) 
-//                            {
-//                            printfln("t%02d",++count," ",t);
-//                            }
-//                        }
-//                    string qname = format("ql%d(%+d:%d)",s,q.sz(),q.Nf());
-//                    Index qbond(qname,mm);
-//                    auto compressor = matrixTensor(std::move(M),bond,qbond);
-//                    for(const ITensor& t : blks) nblock.push_back(t * compressor);
-//                    iq.push_back(IndexQN(qbond,q));
-//                    qC[q] = compressor;
-//                    }
-//                }
-//            }
-//
-//        if(S != Send) 
-//            { 
-//            if(iq.empty()) 
-//                {
-//                cout << "At site " << s << "\n";
-//                Error("convertToIQ: no compatible QNs to put into Link.");
-//                }
-//            linkind[s] = IQIndex(nameint("qL",s),std::move(iq)); 
-//            }
-//        if(S == start)
-//            {
-//            qA.at(s) = (is_mpo ? IQTensor(dag(sites.si(s)),sites.siP(s),linkind.at(s)) 
-//                            : IQTensor(sites.si(s),linkind[s]));
-//            }
-//        else 
-//        if(S == Send)
-//            {
-//            qA.at(s) = (is_mpo ? IQTensor(dag(linkind[sprev]),dag(sites.si(s)),sites.siP(s)) 
-//                            : IQTensor(dag(linkind[sprev]),sites.si(s)));
-//            }
-//        else
-//            {
-//            qA.at(s) = (is_mpo ? IQTensor(dag(linkind[sprev]),dag(sites.si(s)),sites.siP(s),linkind[s]) 
-//                            : IQTensor(dag(linkind[sprev]),sites.si(s),linkind[s]));
-//            }
-//
-//        for(const ITensor& nb : nblock) 
-//            { qA.at(s) += nb; } 
-//        nblock.clear();
-//
-//        if(s==show_s)
-//            {
-//            printfln("qA[%d]",s,qA[s]);
-//            Error("Stopping");
-//            }
-//
-//        } //for loop over s
-//
-//    } //void convertToIQ
+    const int fullrank = (is_mpo ? 4 : 3);
+    int start = 1, end = N;
+
+    for(int j = 1; j <= N; ++j)
+        if(A[j].r() == fullrank)
+        if(A.at(periodicWrap(j-1,N)).r() < fullrank)
+        {
+            start = periodicWrap(j-1,N);
+            //cout << "Got start at " << start << "\n";
+            break;
+        }
+
+    for(int j = 1; j <= N; ++j)
+        if(A[j].r() == fullrank)
+        if(A.at(periodicWrap(j+1,N)).r() < fullrank)
+        {
+            end = periodicWrap(j+1,N);
+            //cout << "Got end at " << end << "\n";
+            break;
+        }
+
+//    cout << "Converting to IQ with (start, end) = " << start<< " "<< end << endl;
+
+    vector<IQIndex> linkind(N+1);
+
+    map<QN,Vector> qD; //Diags of compressor matrices by QN
+
+    using qt_vt = map<QN,vector<ITensor> >::value_type;
+    map<QN,vector<ITensor> > qt; //ITensor blocks by QN
+
+    using qC_vt = map<QN,ITensor>::value_type;
+    map<QN,ITensor> qC; //Compressor ITensors by QN
+
+    ITensor block;
+    vector<ITensor> nblock;
+    vector<IndexQN> iq;
+
+    QN q;
+
+    qC[totalq] = ITensor(); //Represents Virtual index
+    //First value of prev_q below set to totalq
+
+    const int show_s = 0;
+
+    Index bond, prev_bond;
+    int Send = (end < start ? N+end : end);
+
+    for(int S = start; S <= Send; ++S)
+    {
+        PrintData(S);
+        int s = periodicWrap(S,N);
+        int sprev = periodicWrap(S-1,N);
+        int snext = periodicWrap(S+1,N);
+
+        qD.clear();
+        qt.clear();
+
+        if(S > start) prev_bond = commonIndex(A[sprev],A[s],Link);
+        if(S < Send) bond = commonIndex(A[s],A[snext],Link);
+
+        if(s == show_s) { PrintData(A[s]); }
+
+        for(const qC_vt& x : qC)
+            for(int n = 1; n <= Dim;  ++n)
+                for(int u = 1; u <= PDim; ++u)
+                {
+                    //Each compressor represents a particular
+                    //QN channel given by prev_q
+                    const QN& prev_q = x.first;
+                    //Alias previous compressor ITensor to comp
+                    const ITensor& comp = x.second;
+
+                    q = (is_mpo ? prev_q+sites.si(s).qn(n)-sites.si(s).qn(u)
+                                : prev_q-sites.si(s).qn(n));
+
+                    //For the last site, only keep blocks
+                    //compatible with specified totalq i.e. q=0 here
+                    if(S == Send && q != QN()) continue;
+
+                    //Set Site indices of A[s] and its previous Link Index
+                    block = A[s];
+                    if(S != start) block *= dag(comp);
+                    block *= Index(sites.si(s))(n);
+                    if(is_mpo) block *= Index(sites.siP(s))(u);
+
+                    //Initialize D Vector (D records which values of
+                    //the right Link Index to keep for the current QN q)
+                    auto count = qD.count(q);
+                    Vector& D = qD[q];
+                    if(count == 0)
+                    {
+                        resize(D, bond.m());
+                        for(auto& el : D) el = 0;
+                    }
+
+                    if(s == show_s)
+                    {
+                        println("For n = ",n);
+                        printfln("Got a block with norm %.10f",norm(block));
+                        println("bond.m() = ",bond.m());
+                        PrintData(block);
+                        if(s != 1) PrintData(comp);
+                    }
+
+                    bool keep_block = false;
+                    if(S == Send)
+                    { keep_block = true; }
+                    else
+                    {
+                        if(bond.m() == 1 && norm(block) != 0)
+                        {
+                            for(auto& el : D) el = 1;
+                            keep_block = true;
+                        }
+                        else
+                        {
+                            ITensor summed_block;
+                            if(S==start)
+                            { summed_block = block; }
+                            else
+                            {
+                                //Here we sum over the previous link index
+                                //which is already ok, analyze the one to the right
+                                assert(comp.r()==2);
+                                auto ci = comp.inds().begin();
+                                const Index& new_ind = (*ci==prev_bond ? *(ci+1) : *ci);
+                                summed_block = delta(new_ind) * block;
+                            }
+                            //summed_block.print("summed_block");
+
+                            Real rel_cut = -1;
+                            const ITensor& sb = summed_block;
+                            for(int j = 1; j <= bond.m(); ++j)
+                            { rel_cut = std::max(std::fabs(sb.real(bond(j))),rel_cut); }
+                            assert(rel_cut >= 0);
+                            //Real rel_cut = summed_block.norm()/summed_block.vecSize();
+                            rel_cut *= cut;
+                            //cout << "rel_cut == " << rel_cut << "\n";
+
+                            if(rel_cut > 0)
+                                for(int j = 1; j <= bond.m(); ++j)
+                                {
+                                    if(std::fabs(sb.real(bond(j))) > rel_cut)
+                                    {
+                                        D(j-1) = 1;
+                                        keep_block = true;
+                                    }
+                                }
+                        }
+                    } //else (S != Send)
+
+                    if(keep_block)
+                    {
+                        qD[q] = D;
+
+                        auto newindbuilder = IndexSetBuilder(block.r());
+                        for(auto& I: block.inds())
+                            newindbuilder.nextIndex(std::move(I));
+
+                        if(is_mpo)
+                        {
+                            newindbuilder.resize(block.r()+2);
+                            newindbuilder.nextIndex(Index(dag(sites.si(s)(n).indexqn())));
+                            newindbuilder.nextIndex(Index(sites.siP(s)(u).indexqn()));
+                        }
+                        else
+                        {
+                            newindbuilder.resize(block.r()+1);
+                            newindbuilder.nextIndex(Index(sites.si(s)(n).indexqn()));
+                        }
+
+                        IndexSet newinds = newindbuilder.build();
+
+                        if(s==show_s)
+                        {
+                            PrintData(block);
+                            cout << "D = " << D << "\n";
+                        }
+
+                        qt[q].push_back(ITensor(std::move(newinds),std::move(block.store()),std::move(block.scale())));
+
+                    }
+                }
+
+        qC.clear();
+
+        for(const qt_vt& x : qt)
+        {
+            const vector<ITensor>& blks = x.second;
+
+            if(blks.size() != 0)
+            {
+                q = x.first;
+                if(S == Send)
+                { for(const ITensor& t : blks) nblock.push_back(t); }
+                else
+                {
+                    Matrix M;
+                    auto mm = collapseCols(qD[q],M);
+                    if(s==show_s)
+                    {
+                        println("Adding block, mm = ",mm);
+                        Print(q);
+                        cout << "qD[q] = " << qD[q] << "\n";
+                        cout << "M = \n" << M << "\n";
+                        int count = 0;
+                        for(const ITensor& t : blks)
+                        {
+                            printfln("t%02d",++count," ",t);
+                        }
+                    }
+                    string qname = format("ql%d(%+d:%d)",s,Sz(q),Nf(q));
+                    Index qbond(qname,mm);
+                    auto compressor = matrixTensor(std::move(M),bond,qbond);
+                    for(const ITensor& t : blks) nblock.push_back(t * compressor);
+                    iq.push_back(IndexQN(qbond,q));
+                    qC[q] = compressor;
+                }
+            }
+        }
+
+        if(S != Send)
+        {
+            if(iq.empty())
+            {
+                cout << "At site " << s << "\n";
+                Error("convertToIQ: no compatible QNs to put into Link.");
+            }
+            linkind[s] = IQIndex(nameint("qL",s),std::move(iq));
+        }
+        if(S == start)
+        {
+            qA.at(s) = (is_mpo ? IQTensor(dag(sites.si(s)),sites.siP(s),linkind.at(s))
+                               : IQTensor(sites.si(s),linkind[s]));
+        }
+        else
+        if(S == Send)
+        {
+            qA.at(s) = (is_mpo ? IQTensor(dag(linkind[sprev]),dag(sites.si(s)),sites.siP(s))
+                               : IQTensor(dag(linkind[sprev]),sites.si(s)));
+        }
+        else
+        {
+            qA.at(s) = (is_mpo ? IQTensor(dag(linkind[sprev]),dag(sites.si(s)),sites.siP(s),linkind[s])
+                               : IQTensor(dag(linkind[sprev]),sites.si(s),linkind[s]));
+        }
+
+        for(const ITensor& nb : nblock)
+        { qA.at(s) += nb; }
+        nblock.clear();
+
+        if(s==show_s)
+        {
+            printfln("qA[%d]",s,qA[s]);
+            Error("Stopping");
+        }
+
+    } //for loop over s
+
+} //void convertToIQ
 
 /*
 template <class Tensor> 

--- a/itensor/mps/mps.h
+++ b/itensor/mps/mps.h
@@ -144,6 +144,13 @@ class MPSt
     Real 
     normalize();
 
+    void 
+    toIQ(QN totalq, IQMPS& iqpsi, Real cut = 1E-12) const
+        {
+        iqpsi = IQMPS(*sites_);
+        convertToIQ(*sites_,A_,iqpsi.A_,totalq,cut);
+        }
+
     void
     swap(MPSt& other);
 
@@ -257,9 +264,9 @@ class MPSt
 
     }; //class MPSt<Tensor>
 
-//void 
-//convertToIQ(const SiteSet& sites, const std::vector<ITensor>& A, 
-//            std::vector<IQTensor>& qA, QN totalq = QN(), Real cut = 1E-12);
+void 
+convertToIQ(const SiteSet& sites, const std::vector<ITensor>& A, 
+            std::vector<IQTensor>& qA, QN totalq = QN(), Real cut = 1E-12);
 
 template<class T>
 MPSt<T>& 


### PR DESCRIPTION
Update toIQMPO(), toIQ(), convertToIQ() to itensor version 2 .
Those codes are based on the original codes in v1, and tested with the programs in fold samples by substituting
`auto H = IQMPO(ampo)`

with

`
auto A = MPO(ampo);
auto H = A.toIQMPO();
`
which give the same results.