### PR TITLE
Updates to options.mk.sample for OpenBLAS

### DIFF
--- a/options.mk.sample
+++ b/options.mk.sample
@@ -71,7 +71,7 @@ BLAS_LAPACK_LIBFLAGS=-framework Accelerate
 
 #PLATFORM=openblas
 #BLAS_LAPACK_LIBFLAGS=-L/usr/local/opt/openblas/lib -lopenblas
-#BLAS_LAPACK_INCLUDEFLAGS=-I/usr/local/opt/openblas/include
+#BLAS_LAPACK_INCLUDEFLAGS=-I/usr/local/opt/openblas/include -fpermissive -DHAVE_LAPACK_CONFIG_H -DLAPACK_COMPLEX_STRUCTURE
 
 ##
 ## Example using the AMD ACML library


### PR DESCRIPTION
By default OpenBLAS uses C99 complex type in complex.h, which defines I. This definition conflicts with the use of I as template parameters in range.h. Defining the two macros as in the sample circumvents this problem.