### PR TITLE
Use size_t instead of unsigned long.

### DIFF
--- a/itensor/detail/skip_iterator.h
+++ b/itensor/detail/skip_iterator.h
@@ -34,7 +34,7 @@ class SkipIterator
     typedef typename __traits_type::reference reference;
     typedef typename __traits_type::pointer pointer;
 
-    typedef unsigned long size_type;
+    typedef size_t size_type;
 
     public:
 

--- a/itensor/tensor/contract.cc
+++ b/itensor/tensor/contract.cc
@@ -135,7 +135,7 @@ struct CProps
          permuteB_ = false,
          permuteC_ = false;
     public:
-    using Dimension = unsigned long long;
+    using Dimension = size_t;
     Dimension dleft = 1,
               dmid = 1,
               dright = 1;

--- a/itensor/tensor/range.h
+++ b/itensor/tensor/range.h
@@ -22,11 +22,11 @@ template<typename range_type>
 class RangeBuilderT;
 
 //0-indexed
-using Range = RangeT<unsigned long,0ul>;
+using Range = RangeT<size_t,0ul>;
 using RangeBuilder = RangeBuilderT<Range>;
 
 //1-indexed
-using Range1 = RangeT<unsigned long,1ul>;
+using Range1 = RangeT<size_t,1ul>;
 using Range1Builder = RangeBuilderT<Range1>;
 
 template<typename Derived>
@@ -40,7 +40,7 @@ struct isRange
 template<typename index_type>
 struct IndStr
     {
-    using size_type = unsigned long;
+    using size_type = size_t;
     index_type  ind = index_type{}; //convertible to size_type
     size_type   str = 0; //stride
 


### PR DESCRIPTION
size of unsigned long does not match size of itensor::Index for LLP64 systems like Windows, resulting in static_cast errors. Use size_t instead.