### PR TITLE
Fixed error.h to #include <cstdlib>

### DIFF
--- a/itensor/util/error.h
+++ b/itensor/util/error.h
@@ -5,8 +5,8 @@
 #ifndef _error_h
 #define _error_h
 
+#include <cstdlib>
 #include <stdexcept>
-//#include <cstdlib>
 #include <iostream>
 
 void error(const std::string& s);


### PR DESCRIPTION
abort() is declared in cstdlib.