### PR TITLE
Fixed typo in detail::checkArrows

### DIFF
--- a/itensor/itensor_operators.cc
+++ b/itensor/itensor_operators.cc
@@ -64,7 +64,7 @@ checkArrows(IQIndexSet const& is1,
                 println("----------------------------------------");
                 println("IQIndexSet 1 = \n",is1);
                 println("----------------------------------------");
-                println("IQIndexSet 2 = \n",is1);
+                println("IQIndexSet 2 = \n",is2);
                 println("----------------------------------------");
                 printfln("Mismatched IQIndex %s",I1);
                 Error("Mismatched IQIndex arrows");

--- a/itensor/mps/sites/hubbard.h
+++ b/itensor/mps/sites/hubbard.h
@@ -176,6 +176,14 @@ class HubbardSite
             Op.set(UD,UDP,+1);
             }
         else
+        if(opname == "1")
+            {
+            Op.set(Em,EmP,+1); 
+            Op.set(Up,UpP,+1);
+            Op.set(Dn,DnP,+1);
+            Op.set(UD,UDP,+1);
+            }
+        else
         if(opname == "Sz")
             {
             Op.set(Up,UpP,+0.5); 

--- a/itensor/mps/sites/hubbard.h
+++ b/itensor/mps/sites/hubbard.h
@@ -176,14 +176,6 @@ class HubbardSite
             Op.set(UD,UDP,+1);
             }
         else
-        if(opname == "1")
-            {
-            Op.set(Em,EmP,+1); 
-            Op.set(Up,UpP,+1);
-            Op.set(Dn,DnP,+1);
-            Op.set(UD,UDP,+1);
-            }
-        else
         if(opname == "Sz")
             {
             Op.set(Up,UpP,+0.5); 


### PR DESCRIPTION
Found a typo in the detail::checkArrow function and fixed it. Now it prints the correct IndexSet to the console when IQIndices do not have matching arrows. Before, it was giving the same IndexSet twice. 