### PR TITLE
Fixed segfault in plusEq due to recursive call of addAssumeOrth in mpo.h

### DIFF
--- a/itensor/mps/mpo.h
+++ b/itensor/mps/mpo.h
@@ -137,13 +137,13 @@ class MPOt : private MPSt<Tensor>
 
     }; //class MPOt<Tensor>
 
-template<typename T>
-MPOt<T>&
-addAssumeOrth(MPOt<T> & L, MPOt<T> const& R, Args const& args = Args::global()) 
-    { 
-    addAssumeOrth(L,R,{args,"UseSVD",true,"LogRefNorm",L.logRefNorm()}); 
-    return L;
-    }
+// template<typename T>
+// MPOt<T>&
+// addAssumeOrth(MPOt<T> & L, MPOt<T> const& R, Args const& args = Args::global()) 
+//     { 
+//     addAssumeOrth(L,R,{args,"UseSVD",true,"LogRefNorm",L.logRefNorm()}); 
+//     return L;
+//     }
 
 
 template<class T>


### PR DESCRIPTION
Hi there, it's me again. I had the problem that 

```
    auto N = 4;
    auto sites = Hubbard(N);

    auto H1 = MPO(sites);
    auto H2 = MPO(sites);

    H1.plusEq(H2);
```

segfaulted for no obvious reason. After some investigation it turned out `addAssumeOrth(MPOt<T> & L, MPOt<T> const& R, Args const& args = Args::global())` in `mpo.h` was calling itself recursively until the stack was full. The corresponding function in `mps.h` was never called. Just removing it in `mpo.h` fixed the problem and the correct function in `mps.h` is used again. I don't know what the function was for, but if you need it in the future it is still there as a comment. But please keep in mind you have to work on the plusEq for MPOs then. 
