### PR TITLE
Fixes Sweeps Bug and Implemented Read/Write for QCombine

### DIFF
--- a/itensor/itdata/qcombiner.cc
+++ b/itensor/itdata/qcombiner.cc
@@ -17,6 +17,26 @@ namespace itensor {
 const char*
 typeNameOf(QCombiner const& d) { return "QCombiner"; }
 
+void 
+read(std::istream& s, QCombiner & dat)
+    {
+    Range range;
+    itensor::read(s,range);
+
+    using storage_type = typename QCombiner::storage_type;
+    storage_type store;
+    itensor::read(s,store);
+
+    dat = QCombiner(std::move(range),std::move(store));
+    }
+
+void
+write(std::ostream& s, QCombiner const& dat)
+    {
+    itensor::write(s,dat.range());
+    itensor::write(s,dat.store());
+    }
+
 Cplx
 doTask(GetElt<IQIndex> const& g, QCombiner const& c)
     {

--- a/itensor/itdata/qcombiner.h
+++ b/itensor/itdata/qcombiner.h
@@ -19,6 +19,22 @@ class QCombiner
         size_t block  = 0,
                start  = 0,
                extent = 0;
+
+        void 
+        write(std::ostream& s) const
+            { 
+            s.write((char*)&block, sizeof(size_t));
+            s.write((char*)&start, sizeof(size_t));
+            s.write((char*)&extent, sizeof(size_t));
+            }
+    
+        void 
+        read(std::istream& s)
+            { 
+            s.read((char*)&block, sizeof(size_t));
+            s.read((char*)&start, sizeof(size_t));
+            s.read((char*)&extent, sizeof(size_t));
+            }
         };
     public:
     using storage_type = std::vector<BlockRange>;
@@ -43,8 +59,17 @@ class QCombiner
         store_.resize(area(R_));
         }
 
+    explicit
+    QCombiner(Range && range, storage_type && store)
+      : R_(std::move(range)),
+        store_(std::move(store))
+        { }
+
     Range const&
     range() const { return R_; }
+
+    storage_type const&
+    store() const { return store_; }
 
     void
     setBlockRange(Range::iterator const& bit,
@@ -71,11 +96,11 @@ class QCombiner
 const char*
 typeNameOf(QCombiner const& d);
 
-void inline
-read(std::istream& s, QCombiner & dat) { }
+void
+read(std::istream& s, QCombiner & dat);
 
-void inline
-write(std::ostream& s, QCombiner const& dat) { }
+void
+write(std::ostream& s, QCombiner const& dat);
 
 Cplx
 doTask(GetElt<IQIndex> const& g, QCombiner const& c);

--- a/itensor/mps/sweeps.h
+++ b/itensor/mps/sweeps.h
@@ -422,22 +422,22 @@ read(std::istream& s)
     maxm_.resize(maxm_size);
     for(auto& el : maxm_) s.read((char*) &el,sizeof(el));
 
-    auto minm_size = 0;
+    size_t minm_size = 0;
     s.read((char*) &minm_size,sizeof(minm_size));
     minm_.resize(minm_size);
     for(auto& el : minm_) s.read((char*) &el,sizeof(el));
 
-    auto niter_size = 0;
+    size_t niter_size = 0;
     s.read((char*) &niter_size,sizeof(niter_size));
     niter_.resize(niter_size);
     for(auto& el : niter_) s.read((char*) &el,sizeof(el));
 
-    auto cutoff_size = 0;
+    size_t cutoff_size = 0;
     s.read((char*) &cutoff_size,sizeof(cutoff_size));
     cutoff_.resize(cutoff_size);
     for(auto& el : cutoff_) s.read((char*) &el,sizeof(el));
 
-    auto noise_size = 0;
+    size_t noise_size = 0;
     s.read((char*) &noise_size,sizeof(noise_size));
     noise_.resize(noise_size);
     for(auto& el : noise_) s.read((char*) &el,sizeof(el));


### PR DESCRIPTION
Hi, 
I was able to fix the problem I was describing here: http://itensor.org/support/489/segmentation-fault-when-using-combiner

I implemented the necessary read/write methods and now it works. I tried to be as consistent with your style as possible. I hope you can merge it into your repository. 

I also fixed another problem with the read/write of Sweeps. 

If you have questions or comments, just let me know. 

Best,
Lars