### PR TITLE
enclose error funcs in itensor namespace

### DIFF
--- a/itensor/util/error.h
+++ b/itensor/util/error.h
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <iostream>
 
+namespace itensor{
 void error(const std::string& s);
 void error(const std::string& s, int line,const char* file);
 #define Error(exp)  error(exp, __LINE__, __FILE__)
@@ -61,6 +62,6 @@ error(const std::string& s, int line, const char* file = 0)
     abort();
     }
 
-
+}
 
 #endif


### PR DESCRIPTION
to avoid name conflicts to other libraries such as boost