### PR TITLE
order: primeLevel for IndexSet and ITensor

### DIFF
--- a/itensor/indexset.h
+++ b/itensor/indexset.h
@@ -206,6 +206,11 @@ void
 prime(IndexSetT<IndexT>& is, 
       int inc = 1);
 
+template<typename IndexT, typename... VArgs>
+void
+primeLevel(IndexSetT<IndexT>& is,
+           VArgs&&... vargs);
+
 //
 // Increment primelevels of indices in the
 // set by matching them against a list

--- a/itensor/indexset.ih
+++ b/itensor/indexset.ih
@@ -208,6 +208,33 @@ prime(IndexSetT<IndexT>& is,
     prime(is,All,inc); 
     }
 
+template<typename IndexT, typename... VArgs>
+void
+primeLevel(IndexSetT<IndexT>& is,
+           VArgs&&... vargs)
+    {
+    constexpr size_t size = sizeof...(vargs);
+    auto ints = std::array<int,size>{{static_cast<int>(vargs)...}};
+
+    if(size != size_t(is.r()))
+        {
+        println("---------------------------------------------");
+        println("IndexSet indices = \n",is,"\n");
+        println("---------------------------------------------");
+        println("Prime levels provided = ");
+        for(auto& i : ints) println(i);
+        println("---------------------------------------------");
+        Error(format("Wrong number of prime levels passed to primeLevel (expected %d, got %d)",is.r(),size));
+        }
+
+    int i = 0;
+    for(auto& J : is)
+        {
+        J.primeLevel(ints[i]);
+        i++;
+        }
+    }
+
 //template<typename IndexT, typename... Inds>
 //void 
 //prime(IndexSetT<IndexT>& is, 

--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -106,16 +106,13 @@ class ITensorT
     set(IV const& iv1, VArgs&&... ivs)
         -> stdx::if_compiles_return<void,decltype(iv1.index),decltype(iv1.val)>;
 
-    template<typename... VArgs>
+    template<typename Int, typename... VArgs>
     auto
-    set(int iv1, VArgs&&... ivs)
-        -> stdx::if_compiles_return<void,decltype(iv1)>;
+    set(Int iv1, VArgs&&... ivs)
+        -> stdx::enable_if_t<std::is_same<Int,int>::value,void>;
 
     void
     set(Cplx val);
-
-    void
-    set(Real val);
 
     void
     set(std::vector<indexval_type> const& ivs, Cplx val);

--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -108,7 +108,7 @@ class ITensorT
 
     template<typename... VArgs>
     auto
-    set(int const& iv1, VArgs&&... ivs)
+    set(int iv1, VArgs&&... ivs)
         -> stdx::if_compiles_return<void,decltype(iv1)>;
 
     void

--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -106,11 +106,22 @@ class ITensorT
     set(IV const& iv1, VArgs&&... ivs)
         -> stdx::if_compiles_return<void,decltype(iv1.index),decltype(iv1.val)>;
 
+    template<typename... VArgs>
+    auto
+    set(int const& iv1, VArgs&&... ivs)
+        -> stdx::if_compiles_return<void,decltype(iv1)>;
+
     void
     set(Cplx val);
 
     void
+    set(Real val);
+
+    void
     set(std::vector<indexval_type> const& ivs, Cplx val);
+
+    void
+    set(std::vector<int> const& ivs, Cplx val);
 
     //
     // Index Prime Level Methods

--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -135,6 +135,11 @@ class ITensorT
         { itensor::prime(is_,std::forward<VarArgs>(vargs)...); return *this; }
 
     template<typename... VarArgs>
+    ITensorT& 
+    primeLevel(VarArgs&&... vargs)
+        { itensor::primeLevel(is_,std::forward<VarArgs>(vargs)...); return *this; }
+
+    template<typename... VarArgs>
     ITensorT&
     primeExcept(VarArgs&&... vargs)
         { itensor::primeExcept(is_,std::forward<VarArgs>(vargs)...); return *this; }
@@ -324,6 +329,11 @@ template<typename IndexT, typename... VarArgs>
 ITensorT<IndexT>
 prime(ITensorT<IndexT> A, 
       VarArgs&&... vargs);
+
+template<typename IndexT, typename... VarArgs>
+ITensorT<IndexT>
+primeLevel(ITensorT<IndexT> A, 
+           VarArgs&&... vargs);
 
 template<typename IndexT, typename... VarArgs>
 ITensorT<IndexT>

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -623,6 +623,15 @@ prime(ITensorT<IndexT> A,
 
 template<typename IndexT, typename... VarArgs>
 ITensorT<IndexT>
+primeLevel(ITensorT<IndexT> A, 
+           VarArgs&&... vargs)
+    {
+    A.primeLevel(std::forward<VarArgs>(vargs)...);
+    return A;
+    }
+
+template<typename IndexT, typename... VarArgs>
+ITensorT<IndexT>
 primeExcept(ITensorT<IndexT> A, 
             VarArgs&&... vargs)
     {

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -278,7 +278,7 @@ template<typename IntT,
 auto
 getInts(Iter it,
         Cplx & z,
-        Int const& w,
+        Int w,
         Rest&&... rest)
     -> stdx::enable_if_t<std::is_same<Int,int>::value,
                          void>

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -115,7 +115,7 @@ ITensorT<IndexT>::
 operator ITensor() const { Error("ITensorT->ITensor not implemented"); return *this; }
 
 
-template<typename IndexT> 
+template<typename IndexT>
 template <typename... IVs>
 Cplx ITensorT<IndexT>::
 cplx(IVs&&... ivs) const
@@ -126,7 +126,7 @@ cplx(IVs&&... ivs) const
 
     constexpr size_t size = sizeof...(ivs);
     auto vals = std::array<indexval_type,size>{{static_cast<indexval_type>(ivs)...}};
-    if(size != size_t(inds().r())) 
+    if(size != size_t(inds().r()))
         {
         println("---------------------------------------------");
         println("Tensor indices = \n",inds(),"\n");
@@ -141,19 +141,19 @@ cplx(IVs&&... ivs) const
     detail::permute_map(is_,vals,inds,
                 [](indexval_type const& iv) { return iv.val-1; });
     auto z = itensor::doTask(GetElt<IndexT>{is_,inds},store_);
-	try {
+    try {
         return z*scale_.real0(); 
-	    }
-	catch(TooBigForReal const& e)
-	    {
-	    println("too big for real in cplx(...), scale = ",scale());
-	    throw e;
-	    }
-	catch(TooSmallForReal)
-	    {
+        }
+    catch(TooBigForReal const& e)
+        {
+        println("too big for real in cplx(...), scale = ",scale());
+        throw e;
+        }
+    catch(TooSmallForReal)
+        {
         println("warning: too small for real in cplx(...)");
-	    return Cplx(0.,0.);
-	    }
+        return Cplx(0.,0.);
+        }
     return Cplx(NAN,NAN);
     }
 
@@ -189,9 +189,32 @@ getVals(Iter it,
             "Last argument to .set method must be Real or Cplx scalar");
     }
 
+template<typename IntT,
+         typename Iter,
+         typename Int>
+auto
+getInts(Iter it,
+        Cplx & z,
+        Int const& iv)
+    -> stdx::enable_if_t<std::is_same<Int,int>::value,
+                         void>
+    {
+    static_assert(stdx::false_regardless_of<IntT>::value,
+            "Last argument to .set method must be Real or Cplx scalar");
+    }
+
 template<typename IndexValT, typename Iter>
 void
 getVals(Iter it,
+        Cplx & z,
+        Cplx const& w)
+    {
+    z = w;
+    }
+
+template<typename IntT, typename Iter>
+void
+getInts(Iter it,
         Cplx & z,
         Cplx const& w)
     {
@@ -215,9 +238,37 @@ getVals(Iter it,
     getVals<IndexValT>(++it,z,std::forward<Rest&&>(rest)...);
     }
 
+template<typename IntT,
+         typename Iter,
+         typename Int, 
+         typename... Rest>
+auto
+getInts(Iter it,
+        Cplx & z,
+        Int const& iv,
+        Rest&&... rest)
+    -> stdx::enable_if_t<std::is_same<Int,int>::value,
+                         void>
+    {
+    *it = static_cast<IntT>(iv);
+    getInts<IntT>(++it,z,std::forward<Rest&&>(rest)...);
+    }
+
 template<typename IndexValT, typename Iter, typename... Rest>
 bool
 getVals(Iter it,
+        Cplx & z,
+        Cplx w,
+        Rest&&... rest)
+    {
+    static_assert(stdx::false_regardless_of<Iter>::value,
+            "New value passed to .set method must be last argument");
+    return false;
+    }
+
+template<typename IntT, typename Iter, typename... Rest>
+bool
+getInts(Iter it,
         Cplx & z,
         Cplx w,
         Rest&&... rest)
@@ -269,6 +320,44 @@ set(IV const& iv1, VArgs&&... vargs)
     }
 
 template<typename IndexT>
+template<typename... VArgs>
+auto ITensorT<IndexT>::
+set(int const& iv1, VArgs&&... vargs)
+    -> stdx::if_compiles_return<void,decltype(iv1)>
+    {
+    static constexpr auto size = 1+(sizeof...(vargs)-1);
+    std::array<int,size> ints;
+    Cplx z;
+    detail::getInts<int>(ints.begin(),z,iv1,std::forward<VArgs&&>(vargs)...);
+    if(size != size_t(inds().r())) 
+        {
+        println("---------------------------------------------");
+        println("Tensor indices = \n",inds(),"\n");
+        println("---------------------------------------------");
+        println("Indices provided = ");
+        for(auto& iv : ints) println(iv);
+        println("---------------------------------------------");
+        Error(format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+                     inds().r(),size));
+        }
+    auto inds = IntArray(is_.r(),0);
+    for(auto i : range(size))
+        inds[i] = ints[i]-1;
+    //TODO: if !store_ and !is_real, call allocCplx instead
+    //and move this line after check for is_real
+    if(!store_) detail::allocReal(*this,inds);
+    scaleTo(1.);
+    if(z.imag()==0.0)
+        {
+        doTask(SetElt<Real,IndexT>{z.real(),is_,inds},store_);
+        }
+    else
+        {
+        doTask(SetElt<Cplx,IndexT>{z,is_,inds},store_);
+        }
+    }
+
+template<typename IndexT>
 void ITensorT<IndexT>::
 set(Cplx val)
     {
@@ -292,6 +381,21 @@ set(Cplx val)
 
 template<typename IndexT>
 void ITensorT<IndexT>::
+set(Real val)
+    {
+    if(0 != size_t(inds().r())) 
+        {
+        Error(format("Wrong number of IndexVals passed to set (expected %d, got 0)",
+                     inds().r()));
+        }
+    auto inds = IntArray(0,1);
+    if(!store_) detail::allocReal(*this,inds); 
+    scaleTo(1.);
+    doTask(SetElt<Real,IndexT>{val,is_,inds},store_);
+    }
+
+template<typename IndexT>
+void ITensorT<IndexT>::
 set(std::vector<typename IndexT::indexval_type> const& ivals,
     Cplx val)
     {
@@ -310,6 +414,41 @@ set(std::vector<typename IndexT::indexval_type> const& ivals,
     auto inds = IntArray(is_.r(),0);
     detail::permute_map(is_,ivals,inds,
                         [](indexval_type const& iv) { return iv.val-1; });
+    if(!store_) detail::allocReal(*this,inds); 
+    scaleTo(1.);
+    if(val.imag()==0.0)
+        {
+        doTask(SetElt<Real,IndexT>{val.real(),is_,inds},store_);
+        }
+    else
+        {
+        doTask(SetElt<Cplx,IndexT>{val,is_,inds},store_);
+        }
+    }
+
+template<typename IndexT>
+void ITensorT<IndexT>::
+set(std::vector<int> const& ints,
+    Cplx val)
+    {
+    auto size = ints.size();
+    if(size != size_t(inds().r())) 
+        {
+        println("---------------------------------------------");
+        println("Tensor indices = \n",inds(),"\n");
+        println("---------------------------------------------");
+        println("Indices provided = ");
+        for(auto& iv : ints) println(iv);
+        println("---------------------------------------------");
+        Error(format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+                     inds().r(),size));
+        }
+    auto inds = IntArray(is_.r(),0);
+    for(auto i : range(size))
+        inds[i] = ints[i]-1;
+    //TODO: if !store_ and !is_real, call allocCplx instead
+    //detail::permute_map(is_,ivals,inds,
+    //                    [](indexval_type const& iv) { return iv.val-1; });
     if(!store_) detail::allocReal(*this,inds); 
     scaleTo(1.);
     if(val.imag()==0.0)

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -250,7 +250,7 @@ getInts(Iter it,
     -> stdx::enable_if_t<std::is_same<Int,int>::value,
                          void>
     {
-    *it = static_cast<IntT>(iv);
+    *it = iv-1;
     getInts<IntT>(++it,z,std::forward<Rest&&>(rest)...);
     }
 
@@ -322,11 +322,11 @@ set(IV const& iv1, VArgs&&... vargs)
 template<typename IndexT>
 template<typename... VArgs>
 auto ITensorT<IndexT>::
-set(int const& iv1, VArgs&&... vargs)
+set(int iv1, VArgs&&... vargs)
     -> stdx::if_compiles_return<void,decltype(iv1)>
     {
     static constexpr auto size = 1+(sizeof...(vargs)-1);
-    std::array<int,size> ints;
+    auto ints = IntArray(is_.r(),0);
     Cplx z;
     detail::getInts<int>(ints.begin(),z,iv1,std::forward<VArgs&&>(vargs)...);
     if(size != size_t(inds().r())) 
@@ -340,20 +340,17 @@ set(int const& iv1, VArgs&&... vargs)
         Error(format("Wrong number of IndexVals passed to set (expected %d, got %d)",
                      inds().r(),size));
         }
-    auto inds = IntArray(is_.r(),0);
-    for(auto i : range(size))
-        inds[i] = ints[i]-1;
     //TODO: if !store_ and !is_real, call allocCplx instead
     //and move this line after check for is_real
-    if(!store_) detail::allocReal(*this,inds);
+    if(!store_) detail::allocReal(*this,ints);
     scaleTo(1.);
     if(z.imag()==0.0)
         {
-        doTask(SetElt<Real,IndexT>{z.real(),is_,inds},store_);
+        doTask(SetElt<Real,IndexT>{z.real(),is_,ints},store_);
         }
     else
         {
-        doTask(SetElt<Cplx,IndexT>{z,is_,inds},store_);
+        doTask(SetElt<Cplx,IndexT>{z,is_,ints},store_);
         }
     }
 

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -189,32 +189,9 @@ getVals(Iter it,
             "Last argument to .set method must be Real or Cplx scalar");
     }
 
-template<typename IntT,
-         typename Iter,
-         typename Int>
-auto
-getInts(Iter it,
-        Cplx & z,
-        Int const& iv)
-    -> stdx::enable_if_t<std::is_same<Int,int>::value,
-                         void>
-    {
-    static_assert(stdx::false_regardless_of<IntT>::value,
-            "Last argument to .set method must be Real or Cplx scalar");
-    }
-
 template<typename IndexValT, typename Iter>
 void
 getVals(Iter it,
-        Cplx & z,
-        Cplx const& w)
-    {
-    z = w;
-    }
-
-template<typename IntT, typename Iter>
-void
-getInts(Iter it,
         Cplx & z,
         Cplx const& w)
     {
@@ -238,22 +215,6 @@ getVals(Iter it,
     getVals<IndexValT>(++it,z,std::forward<Rest&&>(rest)...);
     }
 
-template<typename IntT,
-         typename Iter,
-         typename Int, 
-         typename... Rest>
-auto
-getInts(Iter it,
-        Cplx & z,
-        Int const& iv,
-        Rest&&... rest)
-    -> stdx::enable_if_t<std::is_same<Int,int>::value,
-                         void>
-    {
-    *it = iv-1;
-    getInts<IntT>(++it,z,std::forward<Rest&&>(rest)...);
-    }
-
 template<typename IndexValT, typename Iter, typename... Rest>
 bool
 getVals(Iter it,
@@ -266,16 +227,64 @@ getVals(Iter it,
     return false;
     }
 
-template<typename IntT, typename Iter, typename... Rest>
-bool
+template<typename IntT,
+         typename Iter,
+         typename Int>
+auto
 getInts(Iter it,
         Cplx & z,
-        Cplx w,
+        Int const& iv)
+    -> stdx::enable_if_t<!(std::is_convertible<Int,Cplx>::value),
+                         void>
+    {
+    static_assert(stdx::false_regardless_of<IntT>::value,
+            "Last argument to .set method must be Real or Cplx scalar");
+    }
+
+template<typename IntT,
+         typename Iter,
+         typename Int>
+auto
+getInts(Iter it,
+        Cplx & z,
+        Int const& w)
+    -> stdx::enable_if_t<std::is_convertible<Int,Cplx>::value,
+                         void>
+    {
+    z = w;
+    }
+
+template<typename IntT,
+         typename Iter,
+         typename Int,
+         typename... Rest>
+auto
+getInts(Iter it,
+        Cplx & z,
+        Int const& w,
         Rest&&... rest)
+    -> stdx::enable_if_t<!(std::is_same<Int,int>::value),
+                         void>
     {
     static_assert(stdx::false_regardless_of<Iter>::value,
             "New value passed to .set method must be last argument");
     return false;
+    }
+
+template<typename IntT,
+         typename Iter,
+         typename Int,
+         typename... Rest>
+auto
+getInts(Iter it,
+        Cplx & z,
+        Int const& w,
+        Rest&&... rest)
+    -> stdx::enable_if_t<std::is_same<Int,int>::value,
+                         void>
+    {
+    *it = w-1;
+    getInts<IntT>(++it,z,std::forward<Rest&&>(rest)...);
     }
 
 } //namespace detail
@@ -320,15 +329,17 @@ set(IV const& iv1, VArgs&&... vargs)
     }
 
 template<typename IndexT>
-template<typename... VArgs>
+template<typename Int,
+         typename... VArgs>
 auto ITensorT<IndexT>::
-set(int iv1, VArgs&&... vargs)
-    -> stdx::if_compiles_return<void,decltype(iv1)>
+set(Int iv1, VArgs&&... vargs)
+    -> stdx::enable_if_t<std::is_same<Int,int>::value,
+                         void>
     {
     static constexpr auto size = 1+(sizeof...(vargs)-1);
     auto ints = IntArray(is_.r(),0);
     Cplx z;
-    detail::getInts<int>(ints.begin(),z,iv1,std::forward<VArgs&&>(vargs)...);
+    detail::getInts<Int>(ints.begin(),z,iv1,std::forward<VArgs&&>(vargs)...);
     if(size != size_t(inds().r())) 
         {
         println("---------------------------------------------");
@@ -374,21 +385,6 @@ set(Cplx val)
         {
         doTask(SetElt<Cplx,IndexT>{val,is_,inds},store_);
         }
-    }
-
-template<typename IndexT>
-void ITensorT<IndexT>::
-set(Real val)
-    {
-    if(0 != size_t(inds().r())) 
-        {
-        Error(format("Wrong number of IndexVals passed to set (expected %d, got 0)",
-                     inds().r()));
-        }
-    auto inds = IntArray(0,1);
-    if(!store_) detail::allocReal(*this,inds); 
-    scaleTo(1.);
-    doTask(SetElt<Real,IndexT>{val,is_,inds},store_);
     }
 
 template<typename IndexT>

--- a/itensor/itensor_operators.cc
+++ b/itensor/itensor_operators.cc
@@ -158,7 +158,8 @@ order(IndexSetT<IndexT> const& iset)
     auto Bis = bind.build();
 
     auto O = Order<IndexT>{P,Ais,Bis};
-    doTask(O, A.store());
+    if(A.store())
+        doTask(O, A.store());
 
     A.is_.swap(Bis);
 

--- a/unittest/indexset_test.cc
+++ b/unittest/indexset_test.cc
@@ -416,6 +416,16 @@ SECTION("Map Prime")
         }
     }
 
+SECTION("PrimeLevel")
+    {
+    IndexSet is(i2,i3,prime(i2),i4);
+    primeLevel(is,1,2,4,5);
+    CHECK(is[0] == prime(i2,1));
+    CHECK(is[1] == prime(i3,2));
+    CHECK(is[2] == prime(i2,4));
+    CHECK(is[3] == prime(i4,5));
+    }
+
 } //PrimeLevelMethods
 
 SECTION("IndexSet Iterator")

--- a/unittest/iqtensor_test.cc
+++ b/unittest/iqtensor_test.cc
@@ -1130,6 +1130,17 @@ CHECK(CIT.inds().index(4).dir()==O3.inds().index(2).dir());
 
 }
 
+SECTION("Set with int")
+{
+auto I = IQIndex("I",Index("I+",1),QN(+1),
+                     Index("I-",1),QN(-1));
+auto J = IQIndex("J",Index("I+",2),QN(+1),
+                     Index("I-",2),QN(-1));
+auto T = IQTensor(I,J);
+T.set(2,1,21.0);
+CHECK_CLOSE(T.real(J(1),I(2)),21.0);
+}
+
 //SECTION("Non-contracting product")
 //    {
 //    SECTION("Case 1")

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -347,12 +347,46 @@ CHECK(isComplex(T));
 CHECK_CLOSE(T.cplx(s1(1),s2(2)),3+5_i);
 }
 
+SECTION("Set Elements Using int")
+{
+auto T = ITensor(s1,s2);
+T.set(1,1,11.0);
+T.set(1,2,12.0);
+T.set(2,1,21.0);
+T.set(2,2,22.0);
+CHECK(!isComplex(T));
+CHECK_CLOSE(T.real(s1(1),s2(1)),11.0);
+CHECK_CLOSE(T.real(s1(1),s2(2)),12.0);
+CHECK_CLOSE(T.real(s1(2),s2(1)),21.0);
+CHECK_CLOSE(T.real(s1(2),s2(2)),22.0);
+
+auto T2 = order(T,s2,s1);
+
+T2.set(2,1,3.0);
+CHECK_CLOSE(T2.real(s1(1),s2(2)),3.0);
+
+T2.set(2,1,3+5_i);
+CHECK(isComplex(T2));
+CHECK_CLOSE(T2.cplx(s1(1),s2(2)),3+5_i);
+}
+
 SECTION("Set Using vector<IndexVal>")
 {
 auto T = ITensor(s1,s2);
 auto v12 = vector<IndexVal>{{s2(2),s1(1)}};
 T.set(v12,12);
 auto v21 = vector<IndexVal>{{s1(2),s2(1)}};
+T.set(v21,21);
+CHECK_CLOSE(T.real(s1(1),s2(2)),12);
+CHECK_CLOSE(T.real(s1(2),s2(1)),21);
+}
+
+SECTION("Set Using vector<int>")
+{
+auto T = ITensor(s1,s2);
+auto v12 = vector<int>{{1,2}};
+T.set(v12,12);
+auto v21 = vector<int>{{2,1}};
 T.set(v21,21);
 CHECK_CLOSE(T.real(s1(1),s2(2)),12);
 CHECK_CLOSE(T.real(s1(2),s2(1)),21);

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -350,20 +350,20 @@ CHECK_CLOSE(T.cplx(s1(1),s2(2)),3+5_i);
 SECTION("Set Elements Using int")
 {
 auto T = ITensor(s1,s2);
-T.set(1,1,11.0);
-T.set(1,2,12.0);
-T.set(2,1,21.0);
-T.set(2,2,22.0);
+T.set(1,1,11);
+T.set(1,2,12);
+T.set(2,1,21);
+T.set(2,2,22);
 CHECK(!isComplex(T));
-CHECK_CLOSE(T.real(s1(1),s2(1)),11.0);
-CHECK_CLOSE(T.real(s1(1),s2(2)),12.0);
-CHECK_CLOSE(T.real(s1(2),s2(1)),21.0);
-CHECK_CLOSE(T.real(s1(2),s2(2)),22.0);
+CHECK_CLOSE(T.real(s1(1),s2(1)),11);
+CHECK_CLOSE(T.real(s1(1),s2(2)),12);
+CHECK_CLOSE(T.real(s1(2),s2(1)),21);
+CHECK_CLOSE(T.real(s1(2),s2(2)),22);
 
 auto T2 = order(T,s2,s1);
 
-T2.set(2,1,3.0);
-CHECK_CLOSE(T2.real(s1(1),s2(2)),3.0);
+T2.set(2,1,3);
+CHECK_CLOSE(T2.real(s1(1),s2(2)),3);
 
 T2.set(2,1,3+5_i);
 CHECK(isComplex(T2));
@@ -2434,6 +2434,8 @@ SECTION("Scalar Storage")
         {
         S1.set(4.5);
         CHECK_CLOSE(S1.real(),4.5);
+        S1.set(4);
+        CHECK_CLOSE(S1.real(),4);
         S1.set(1.+3._i);
         CHECK(isComplex(S1));
         CHECK_CLOSE(S1.cplx(),1.+3._i);

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -1331,6 +1331,25 @@ SECTION("Prime")
     CHECK(T.inds()[3] == prime(x,2));
     }
 
+SECTION("PrimeLevel")
+    {
+    Index x("x",2,Xtype),
+          z("z",2,Ztype),
+          v("v",2,Vtype);
+    ITensor T(x,z,v,prime(x));
+    T.primeLevel(2,4,3,5);
+    CHECK(T.inds()[0] == prime(x,2));
+    CHECK(T.inds()[1] == prime(z,4));
+    CHECK(T.inds()[2] == prime(v,3));
+    CHECK(T.inds()[3] == prime(x,5));
+
+    auto T2 = primeLevel(T,3,2,1,0);
+    CHECK(T2.inds()[0] == prime(x,3));
+    CHECK(T2.inds()[1] == prime(z,2));
+    CHECK(T2.inds()[2] == prime(v,1));
+    CHECK(T2.inds()[3] == prime(x,0));
+    }
+
 SECTION("SwapPrimeTest")
     {
     CHECK_EQUAL(A.real(s1(1),prime(s1)(1)),11);


### PR DESCRIPTION
Adds primeLevel function for IndexSets and ITensors so that the prime levels of ITensors can be directly specified given the index ordering (closes #143).