### PR TITLE
Extend .set to work with long int

### DIFF
--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -103,14 +103,14 @@ class ITensorT
     template <typename IV, typename... IVs>
     auto
     cplx(IV const& iv1, IVs&&... ivs) const
-        -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value
-                             || std::is_same<IV,IQIndexVal>::value,
+        -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
                              Cplx>;
 
     template <typename Int, typename... Ints>
     auto
     cplx(Int iv1, Ints&&... ivs) const
-        -> stdx::enable_if_t<std::is_convertible<Int,int>::value,Cplx>;
+        -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
+                             Cplx>;
 
     Cplx
     cplx() const;
@@ -121,12 +121,14 @@ class ITensorT
     template<typename IV, typename... VArgs>
     auto
     set(IV const& iv1, VArgs&&... ivs)
-        -> stdx::if_compiles_return<void,decltype(iv1.index),decltype(iv1.val)>;
+        -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
+                             void>;
 
     template<typename Int, typename... VArgs>
     auto
     set(Int iv1, VArgs&&... ivs)
-        -> stdx::enable_if_t<std::is_convertible<Int,int>::value,void>;
+        -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
+                             void>;
 
     void
     set(Cplx val);

--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -101,12 +101,16 @@ class ITensorT
     real(IndexVals&&... ivs) const;
 
     template <typename IV, typename... IVs>
-    Cplx
-    cplx(IV const& iv1, IVs&&... ivs) const;
+    auto
+    cplx(IV const& iv1, IVs&&... ivs) const
+        -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value
+                             || std::is_same<IV,IQIndexVal>::value,
+                             Cplx>;
 
-    template <typename... Ints>
-    Cplx
-    cplx(int iv1, Ints&&... ivs) const;
+    template <typename Int, typename... Ints>
+    auto
+    cplx(Int iv1, Ints&&... ivs) const
+        -> stdx::enable_if_t<std::is_convertible<Int,int>::value,Cplx>;
 
     Cplx
     cplx() const;
@@ -122,7 +126,7 @@ class ITensorT
     template<typename Int, typename... VArgs>
     auto
     set(Int iv1, VArgs&&... ivs)
-        -> stdx::enable_if_t<std::is_same<Int,int>::value,void>;
+        -> stdx::enable_if_t<std::is_convertible<Int,int>::value,void>;
 
     void
     set(Cplx val);

--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -103,14 +103,12 @@ class ITensorT
     template <typename IV, typename... IVs>
     auto
     cplx(IV const& iv1, IVs&&... ivs) const
-        -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
-                             Cplx>;
+         -> stdx::if_compiles_return<Cplx,decltype(iv1.index),decltype(iv1.val)>;
 
     template <typename Int, typename... Ints>
     auto
-    cplx(Int iv1, Ints&&... ivs) const
-        -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
-                             Cplx>;
+    cplx(Int iv1, Ints... ivs) const
+        -> stdx::enable_if_t<std::is_integral<Int>::value && stdx::and_<std::is_integral<Ints>...>::value,Cplx>;
 
     Cplx
     cplx() const;
@@ -121,14 +119,12 @@ class ITensorT
     template<typename IV, typename... VArgs>
     auto
     set(IV const& iv1, VArgs&&... ivs)
-        -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
-                             void>;
+        -> stdx::if_compiles_return<void,decltype(iv1.index),decltype(iv1.val)>;
 
     template<typename Int, typename... VArgs>
     auto
     set(Int iv1, VArgs&&... ivs)
-        -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
-                             void>;
+        -> stdx::enable_if_t<std::is_integral<Int>::value,void>;
 
     void
     set(Cplx val);

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -119,8 +119,7 @@ template<typename IV, typename... IVs>
 auto ITensorT<IndexT>::
 cplx(IV const& iv1, IVs&&... ivs) const
     -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value 
-                         || std::is_same<IV,IQIndexVal>::value,
-                         Cplx>
+                         || std::is_same<IV,IQIndexVal>::value, Cplx>
     {
     using indexval_type = typename IndexT::indexval_type;
 
@@ -163,13 +162,13 @@ template<typename IndexT>
 template<typename Int, typename... Ints>
 auto ITensorT<IndexT>::
 cplx(Int iv1, Ints&&... ivs) const
-    -> stdx::enable_if_t<std::is_convertible<Int,int>::value,
+    -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
                          Cplx>
     {
     if(!store()) Error("tensor storage unallocated");
 
     constexpr size_t size = sizeof...(ivs)+1;
-    auto ints = std::array<Int,size>{{iv1,static_cast<Int>(ivs)...}};
+    auto ints = std::array<Int,size>{{iv1,static_cast<int>(ivs)...}};
     if(size != size_t(inds().r()))
         {
         println("---------------------------------------------");
@@ -178,7 +177,7 @@ cplx(Int iv1, Ints&&... ivs) const
         print("Indices provided = ");
         for(auto i : ints) print(" ",i);
         println("\n---------------------------------------------");
-        Error(format("Wrong number of IndexVals passed to real/cplx (expected %d, got %d)",inds().r(),size));
+        Error(format("Wrong number of ints passed to real/cplx (expected %d, got %d)",inds().r(),size));
         }
 
     auto inds = IntArray(size);
@@ -252,8 +251,7 @@ auto
 getVals(Iter it,
         Cplx & z,
         IV const& iv)
-    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value 
-                      || std::is_same<IV,IQIndexVal>::value,
+    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
                          void>
     {
     static_assert(stdx::false_regardless_of<IndexValT>::value,
@@ -278,8 +276,7 @@ getVals(Iter it,
         Cplx & z,
         IV const& iv,
         Rest&&... rest)
-    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value 
-                      || std::is_same<IV,IQIndexVal>::value,
+    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
                          void>
     {
     *it = static_cast<IndexValT>(iv);
@@ -300,12 +297,12 @@ getVals(Iter it,
 
 template<typename IntT,
          typename Iter,
-         typename Int>
+         typename Arg>
 auto
 getInts(Iter it,
         Cplx & z,
-        Int const& iv)
-    -> stdx::enable_if_t<!(std::is_convertible<Int,Cplx>::value),
+        Arg const& iv)
+    -> stdx::enable_if_t<!(std::is_convertible<Arg,Cplx>::value),
                          void>
     {
     static_assert(stdx::false_regardless_of<IntT>::value,
@@ -314,12 +311,12 @@ getInts(Iter it,
 
 template<typename IntT,
          typename Iter,
-         typename Int>
+         typename Arg>
 auto
 getInts(Iter it,
         Cplx & z,
-        Int const& w)
-    -> stdx::enable_if_t<std::is_convertible<Int,Cplx>::value,
+        Arg const& w)
+    -> stdx::enable_if_t<std::is_convertible<Arg,Cplx>::value,
                          void>
     {
     z = w;
@@ -334,7 +331,7 @@ getInts(Iter it,
         Cplx & z,
         Int const& w,
         Rest&&... rest)
-    -> stdx::enable_if_t<!(std::is_convertible<Int,int>::value),
+    -> stdx::enable_if_t<!(std::is_same<Int,int>::value || std::is_same<Int,long int>::value),
                          void>
     {
     static_assert(stdx::false_regardless_of<Iter>::value,
@@ -351,7 +348,7 @@ getInts(Iter it,
         Cplx & z,
         Int w,
         Rest&&... rest)
-    -> stdx::enable_if_t<std::is_convertible<Int,int>::value,
+    -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
                          void>
     {
     *it = w-1;
@@ -365,7 +362,8 @@ template<typename IndexT>
 template<typename IV, typename... VArgs>
 auto ITensorT<IndexT>::
 set(IV const& iv1, VArgs&&... vargs)
-    -> stdx::if_compiles_return<void,decltype(iv1.index),decltype(iv1.val)>
+    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value
+                         || std::is_same<IV,IQIndexVal>::value, void>
     {
     static constexpr auto size = 1+(sizeof...(vargs)-1);
     std::array<indexval_type,size> vals;
@@ -400,11 +398,10 @@ set(IV const& iv1, VArgs&&... vargs)
     }
 
 template<typename IndexT>
-template<typename Int,
-         typename... VArgs>
+template<typename Int, typename... VArgs>
 auto ITensorT<IndexT>::
 set(Int iv1, VArgs&&... vargs)
-    -> stdx::enable_if_t<std::is_convertible<Int,int>::value,
+    -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
                          void>
     {
     static constexpr auto size = 1+(sizeof...(vargs)-1);
@@ -420,7 +417,7 @@ set(Int iv1, VArgs&&... vargs)
         for(auto& i : ints) print(" ",1+i);
         println();
         println("---------------------------------------------");
-        Error(format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+        Error(format("Wrong number of ints passed to set (expected %d, got %d)",
                      inds().r(),size));
         }
     //TODO: if !store_ and !is_real, call allocCplx instead

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -116,8 +116,11 @@ operator ITensor() const { Error("ITensorT->ITensor not implemented"); return *t
 
 template<typename IndexT>
 template<typename IV, typename... IVs>
-Cplx ITensorT<IndexT>::
+auto ITensorT<IndexT>::
 cplx(IV const& iv1, IVs&&... ivs) const
+    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value 
+                         || std::is_same<IV,IQIndexVal>::value,
+                         Cplx>
     {
     using indexval_type = typename IndexT::indexval_type;
 
@@ -157,14 +160,16 @@ cplx(IV const& iv1, IVs&&... ivs) const
     }
 
 template<typename IndexT>
-template<typename... Ints>
-Cplx ITensorT<IndexT>::
-cplx(int iv1, Ints&&... ivs) const
+template<typename Int, typename... Ints>
+auto ITensorT<IndexT>::
+cplx(Int iv1, Ints&&... ivs) const
+    -> stdx::enable_if_t<std::is_convertible<Int,int>::value,
+                         Cplx>
     {
     if(!store()) Error("tensor storage unallocated");
 
     constexpr size_t size = sizeof...(ivs)+1;
-    auto ints = std::array<int,size>{{iv1,static_cast<int>(ivs)...}};
+    auto ints = std::array<Int,size>{{iv1,static_cast<Int>(ivs)...}};
     if(size != size_t(inds().r()))
         {
         println("---------------------------------------------");
@@ -329,7 +334,7 @@ getInts(Iter it,
         Cplx & z,
         Int const& w,
         Rest&&... rest)
-    -> stdx::enable_if_t<!(std::is_same<Int,int>::value),
+    -> stdx::enable_if_t<!(std::is_convertible<Int,int>::value),
                          void>
     {
     static_assert(stdx::false_regardless_of<Iter>::value,
@@ -346,7 +351,7 @@ getInts(Iter it,
         Cplx & z,
         Int w,
         Rest&&... rest)
-    -> stdx::enable_if_t<std::is_same<Int,int>::value,
+    -> stdx::enable_if_t<std::is_convertible<Int,int>::value,
                          void>
     {
     *it = w-1;
@@ -399,7 +404,7 @@ template<typename Int,
          typename... VArgs>
 auto ITensorT<IndexT>::
 set(Int iv1, VArgs&&... vargs)
-    -> stdx::enable_if_t<std::is_same<Int,int>::value,
+    -> stdx::enable_if_t<std::is_convertible<Int,int>::value,
                          void>
     {
     static constexpr auto size = 1+(sizeof...(vargs)-1);

--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -118,8 +118,7 @@ template<typename IndexT>
 template<typename IV, typename... IVs>
 auto ITensorT<IndexT>::
 cplx(IV const& iv1, IVs&&... ivs) const
-    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value 
-                         || std::is_same<IV,IQIndexVal>::value, Cplx>
+    -> stdx::if_compiles_return<Cplx,decltype(iv1.index),decltype(iv1.val)>
     {
     using indexval_type = typename IndexT::indexval_type;
 
@@ -161,9 +160,8 @@ cplx(IV const& iv1, IVs&&... ivs) const
 template<typename IndexT>
 template<typename Int, typename... Ints>
 auto ITensorT<IndexT>::
-cplx(Int iv1, Ints&&... ivs) const
-    -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
-                         Cplx>
+cplx(Int iv1, Ints... ivs) const
+    -> stdx::enable_if_t<std::is_integral<Int>::value && stdx::and_<std::is_integral<Ints>...>::value,Cplx>
     {
     if(!store()) Error("tensor storage unallocated");
 
@@ -251,8 +249,7 @@ auto
 getVals(Iter it,
         Cplx & z,
         IV const& iv)
-    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
-                         void>
+    -> stdx::if_compiles_return<void,decltype(iv.index),decltype(iv.val)>
     {
     static_assert(stdx::false_regardless_of<IndexValT>::value,
             "Last argument to .set method must be Real or Cplx scalar");
@@ -276,8 +273,7 @@ getVals(Iter it,
         Cplx & z,
         IV const& iv,
         Rest&&... rest)
-    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value || std::is_same<IV,IQIndexVal>::value,
-                         void>
+    -> stdx::if_compiles_return<void,decltype(iv.index),decltype(iv.val)>
     {
     *it = static_cast<IndexValT>(iv);
     getVals<IndexValT>(++it,z,std::forward<Rest&&>(rest)...);
@@ -302,8 +298,7 @@ auto
 getInts(Iter it,
         Cplx & z,
         Arg const& iv)
-    -> stdx::enable_if_t<!(std::is_convertible<Arg,Cplx>::value),
-                         void>
+    -> stdx::enable_if_t<not std::is_convertible<Arg,Cplx>::value,void>
     {
     static_assert(stdx::false_regardless_of<IntT>::value,
             "Last argument to .set method must be Real or Cplx scalar");
@@ -316,8 +311,7 @@ auto
 getInts(Iter it,
         Cplx & z,
         Arg const& w)
-    -> stdx::enable_if_t<std::is_convertible<Arg,Cplx>::value,
-                         void>
+    -> stdx::enable_if_t<std::is_convertible<Arg,Cplx>::value,void>
     {
     z = w;
     }
@@ -331,8 +325,7 @@ getInts(Iter it,
         Cplx & z,
         Int const& w,
         Rest&&... rest)
-    -> stdx::enable_if_t<!(std::is_same<Int,int>::value || std::is_same<Int,long int>::value),
-                         void>
+    -> stdx::enable_if_t<not std::is_integral<Int>::value,void>
     {
     static_assert(stdx::false_regardless_of<Iter>::value,
             "New value passed to .set method must be last argument");
@@ -348,8 +341,7 @@ getInts(Iter it,
         Cplx & z,
         Int w,
         Rest&&... rest)
-    -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
-                         void>
+    -> stdx::enable_if_t<std::is_integral<Int>::value,void>
     {
     *it = w-1;
     getInts<IntT>(++it,z,std::forward<Rest&&>(rest)...);
@@ -362,8 +354,7 @@ template<typename IndexT>
 template<typename IV, typename... VArgs>
 auto ITensorT<IndexT>::
 set(IV const& iv1, VArgs&&... vargs)
-    -> stdx::enable_if_t<std::is_same<IV,IndexVal>::value
-                         || std::is_same<IV,IQIndexVal>::value, void>
+    -> stdx::if_compiles_return<void,decltype(iv1.index),decltype(iv1.val)>
     {
     static constexpr auto size = 1+(sizeof...(vargs)-1);
     std::array<indexval_type,size> vals;
@@ -401,8 +392,7 @@ template<typename IndexT>
 template<typename Int, typename... VArgs>
 auto ITensorT<IndexT>::
 set(Int iv1, VArgs&&... vargs)
-    -> stdx::enable_if_t<std::is_same<Int,int>::value || std::is_same<Int,long int>::value,
-                         void>
+    -> stdx::enable_if_t<std::is_integral<Int>::value,void>
     {
     static constexpr auto size = 1+(sizeof...(vargs)-1);
     auto ints = IntArray(size,0);
@@ -1005,10 +995,9 @@ moveToBack(IndexSetT<IndexT> const& isb, IndexSetT<IndexT> const& is)
 //Version of order accepting syntax: T.order(i,j,"...")
 template <typename IndexT>
 template <typename... Indxs>
-typename std::enable_if<not (stdx::and_<std::is_same<IndexT, Indxs>...>::value), 
-                        ITensorT<IndexT>&>::type
-ITensorT<IndexT>::
+auto ITensorT<IndexT>::
 order(IndexT const& ind1, Indxs const&... inds)
+    -> stdx::enable_if_t<not stdx::and_<std::is_same<IndexT, Indxs>...>::value,ITensorT<IndexT>&>
     {
     static constexpr auto size = 1+(sizeof...(inds)-1);
     auto isf = IndexSetT<IndexT>(size);
@@ -1020,10 +1009,9 @@ order(IndexT const& ind1, Indxs const&... inds)
 //Version of order accepting syntax: T.order(i,j,k)
 template <typename IndexT>
 template <typename... Indxs>
-typename std::enable_if<(stdx::and_<std::is_same<IndexT, Indxs>...>::value), 
-                        ITensorT<IndexT>&>::type
-ITensorT<IndexT>::
+auto ITensorT<IndexT>::
 order(IndexT const& ind1, Indxs const&... inds)
+    -> stdx::enable_if_t<stdx::and_<std::is_same<IndexT, Indxs>...>::value,ITensorT<IndexT>&>
     {
     order(IndexSetT<IndexT>(ind1, inds...));
     return *this;

--- a/itensor/itensor_operators.cc
+++ b/itensor/itensor_operators.cc
@@ -142,7 +142,7 @@ order(IndexSetT<IndexT> const& iset)
     auto Ais = A.inds();
     auto r = Ais.r();
 
-    if(r != size_t(iset.r()))
+    if(size_t(r) != size_t(iset.r()))
         {
         println("---------------------------------------------");
         println("Tensor indices = \n",Ais,"\n");

--- a/unittest/iqtensor_test.cc
+++ b/unittest/iqtensor_test.cc
@@ -1223,6 +1223,20 @@ CHECK_CLOSE(T.real(J(1),I(2)),21);
 CHECK_CLOSE(T.real(2,1),21);
 }
 
+SECTION("Set and Get with long int")
+{
+auto I = IQIndex("I",Index("I+",1),QN(+1),
+                     Index("I-",1),QN(-1));
+auto J = IQIndex("J",Index("I+",2),QN(+1),
+                     Index("I-",2),QN(-1));
+auto T = IQTensor(I,J);
+long int i1 = 1,
+         i2 = 2;
+T.set(i2,i1,21);
+CHECK_CLOSE(T.real(J(1),I(2)),21);
+CHECK_CLOSE(T.real(i2,i1),21);
+}
+
 //SECTION("Non-contracting product")
 //    {
 //    SECTION("Case 1")

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -376,18 +376,18 @@ auto T = ITensor(s1,s2);
 long int i1 = 1,
          i2 = 2;
 T.set(i1,i1,11);
-T.set(i1,i2,12);
-T.set(i2,i1,21);
-T.set(i2,i2,22);
+T.set(1,i2,12);
+T.set(i2,1,21);
+T.set(i2,2,22);
 CHECK(!isComplex(T));
 CHECK_CLOSE(T.real(s1(1),s2(1)),11);
 CHECK_CLOSE(T.real(s1(1),s2(2)),12);
 CHECK_CLOSE(T.real(s1(2),s2(1)),21);
 CHECK_CLOSE(T.real(s1(2),s2(2)),22);
 CHECK_CLOSE(T.real(i1,i1),11);
-CHECK_CLOSE(T.real(i1,i2),12);
-CHECK_CLOSE(T.real(i2,i1),21);
-CHECK_CLOSE(T.real(i2,i2),22);
+CHECK_CLOSE(T.real(i1,2),12);
+CHECK_CLOSE(T.real(2,i1),21);
+CHECK_CLOSE(T.real(i2,2),22);
 
 T.set(i2,i1,3+5_i);
 CHECK(isComplex(T));

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -370,6 +370,31 @@ CHECK_CLOSE(T.cplx(s1(2),s2(1)),3+5_i);
 CHECK_CLOSE(T.cplx(2,1),3+5_i);
 }
 
+SECTION("Set and Get Elements Using long int")
+{
+auto T = ITensor(s1,s2);
+long int i1 = 1,
+         i2 = 2;
+T.set(i1,i1,11);
+T.set(i1,i2,12);
+T.set(i2,i1,21);
+T.set(i2,i2,22);
+CHECK(!isComplex(T));
+CHECK_CLOSE(T.real(s1(1),s2(1)),11);
+CHECK_CLOSE(T.real(s1(1),s2(2)),12);
+CHECK_CLOSE(T.real(s1(2),s2(1)),21);
+CHECK_CLOSE(T.real(s1(2),s2(2)),22);
+CHECK_CLOSE(T.real(i1,i1),11);
+CHECK_CLOSE(T.real(i1,i2),12);
+CHECK_CLOSE(T.real(i2,i1),21);
+CHECK_CLOSE(T.real(i2,i2),22);
+
+T.set(i2,i1,3+5_i);
+CHECK(isComplex(T));
+CHECK_CLOSE(T.cplx(s1(2),s2(1)),3+5_i);
+CHECK_CLOSE(T.cplx(i2,i1),3+5_i);
+}
+
 SECTION("Set Using vector<IndexVal>")
 {
 auto T = ITensor(s1,s2);


### PR DESCRIPTION
I noticed with the following type of code:
```
Index i("i",2), j("j",2);
auto A = randomTensor(i,j);
for(auto s : range1(i.m())) A.set(s,s,sqrt(A.real(s,s)));
```
the new .set, .cplx, etc. aren't dispatching correctly, since the new versions were limited to just accepting `int`'s while `s` above becomes type `long int`, so it tries to use the versions that are meant for `IndexVal`'s and throws an error. I extended .cplx and .set to accept anything that is convertible to an `int`, let me know if this seems like the way to go.