### PR TITLE
Minor fixes

### DIFF
--- a/itensor/indexset.ih
+++ b/itensor/indexset.ih
@@ -505,7 +505,7 @@ dir(const IndexSetT<IndexT>& is, const IndexT& I)
 
 
 template <class IndexT>
-const IndexT&
+IndexT
 finddir(const IndexSetT<IndexT>& iset, Arrow dir)
     {
     for(const auto& J : iset)
@@ -534,7 +534,7 @@ findindex(const IndexSetT<IndexT>& iset,
     }
 
 template <class IndexT>
-const IndexT&
+IndexT
 findtype(const IndexSetT<IndexT>& iset, IndexType t)
 	{
     for(auto& J : iset)

--- a/itensor/qn.h
+++ b/itensor/qn.h
@@ -93,8 +93,8 @@ struct QNVal
     void
     set(qn_t v);
 
-    QNVal&
-    operator-() { set(-val_); return *this; }
+    QNVal
+    operator-() const { return QNVal(-val_, mod_); }
     };
 
 //


### PR DESCRIPTION
- `indexset.ih`
Return an empty local `static const IndexT` instance instead of creating one every time. This fixes warnings since `findtype` and `finddir` both return lvalue references.
- `qn.h`
Defined unary minus for `const QNVal`