### PR TITLE
Fix catching polymorphic `TooSmallForReal` by value

### DIFF
--- a/itensor/itensor_interface.ih
+++ b/itensor/itensor_interface.ih
@@ -149,7 +149,7 @@ cplx(IV const& iv1, IVs&&... ivs) const
         println("too big for real in cplx(...), scale = ",scale());
         throw e;
         }
-    catch(TooSmallForReal)
+    catch(TooSmallForReal const&)
         {
         println("warning: too small for real in cplx(...)");
         return Cplx(0.,0.);
@@ -190,7 +190,7 @@ cplx(Int iv1, Ints... ivs) const
         println("too big for real in cplx(...), scale = ",scale());
         throw e;
         }
-    catch(TooSmallForReal)
+    catch(TooSmallForReal const&)
         {
         println("warning: too small for real in cplx(...)");
         return Cplx(0.,0.);
@@ -217,7 +217,7 @@ cplx() const
         println("too big for real in cplx(...), scale = ",scale());
         throw e;
         }
-    catch(TooSmallForReal)
+    catch(TooSmallForReal const&)
         {
         println("warning: too small for real in cplx(...)");
         return Cplx(0.,0.);


### PR DESCRIPTION
`itensor::TooSmallForReal` is derived from `std::runtime_error`.  This is a
polymorphic type, so cathing it by value is dangerous.  gcc 8 warns about
this:

    [...]/itensor/itensor/itensor_interface.ih:220:5: warning:
    catching polymorphic type ‘class itensor::TooSmallForReal’ by value
         catch(TooSmallForReal)
         ^~~~~

This fixes this bug.