### PR TITLE
AutoMPO for iDMRG

### DIFF
--- a/sample/idmrg.cc
+++ b/sample/idmrg.cc
@@ -12,7 +12,24 @@ int main(int argc, char* argv[])
 
     auto sites = SpinOne(N);
 
-    IQMPO H = Heisenberg(sites,{"Infinite=",true});
+    bool use_autompo = true;
+
+    IQMPO H;
+
+    if(use_autompo)
+    {
+        auto ampo = AutoMPO(sites);
+        for(int j = 1; j <= N; ++j)
+        {
+            ampo += 0.5,"S+",j,"S-",j+1;
+            ampo += 0.5,"S-",j,"S+",j+1;
+            ampo +=     "Sz",j,"Sz",j+1;
+        }
+
+        H = toMPO<IQTensor>(ampo, {"Infinite",true, "Verbose",true});
+    }
+    else
+        H = Heisenberg(sites,{"Infinite=",true});
 
     auto sweeps = Sweeps(20);
     sweeps.maxm() = 20,80,140,200;


### PR DESCRIPTION
Adjusting AutoMPO implementation to work for infinite systems.

When specifying the Hamiltonian, terms that connect a site in one unit cell to a site in the next unit cell should be specified with site indices (i, N+j), where i and j are the site indices within a unit cell and N is the number of sites in a unit cell.

Note that AutoMPO does not perform any compression in this case - when constructing the finalMPO, the SVD is skipped and the matrix elements of the MPO are taken directly from tempMPO.