### PR TITLE
Add applyMPO method which allows for a starting guess wavefunction

### DIFF
--- a/itensor/mps/mpo.h
+++ b/itensor/mps/mpo.h
@@ -288,6 +288,13 @@ applyMPO(MPOt<Tensor> const& K,
          MPSt<Tensor> const& x,
          Args const& args = Args::global());
 
+template<class Tensor>
+MPSt<Tensor>
+applyMPO(MPOt<Tensor> const& K,
+         MPSt<Tensor> const& x,
+         MPSt<Tensor> const& x0,
+         Args const& args = Args::global());
+
 //
 // Applies an MPO to an MPS using the zip-up method described
 // more fully in Stoudenmire and White, New. J. Phys. 12, 055026 (2010).

--- a/unittest/mpo_test.cc
+++ b/unittest/mpo_test.cc
@@ -131,6 +131,8 @@ SECTION("Regression Test")
 SECTION("applyMPO (DensityMatrix)")
     {
 
+    auto method = "DensityMatrix";
+
     auto N = 10;
     auto sites = SpinHalf(N);
 
@@ -157,18 +159,20 @@ SECTION("applyMPO (DensityMatrix)")
         }
 
     // Apply K to psi to entangle psi
-    psi = applyMPO(K,psi,{"Cutoff=",0.,"Maxm=",100,"Method=","DensityMatrix"});
+    psi = applyMPO(K,psi,{"Cutoff=",0.,"Maxm=",100});
     psi /= norm(psi);
 
-    auto Hpsi = applyMPO(H,psi,{"Cutoff=",1E-13,"Maxm=",5000,"Method=","DensityMatrix"});
+    auto Hpsi = applyMPO(H,psi,{"Method=",method,"Cutoff=",1E-13,"Maxm=",5000});
 
-    CHECK_CLOSE(overlap(Hpsi,H,psi),overlap(Hpsi,Hpsi));
+    CHECK_CLOSE(checkMPOProd(Hpsi,H,psi),0.);
 
     }
 
 SECTION("applyMPO (Fit)")
     {
 
+    auto method = "Fit";
+
     auto N = 10;
     auto sites = SpinHalf(N);
 
@@ -195,12 +199,17 @@ SECTION("applyMPO (Fit)")
         }
 
     // Apply K to psi to entangle psi
-    psi = applyMPO(K,psi,{"Cutoff=",0.,"Maxm=",100,"Method=","DensityMatrix"});
+    psi = applyMPO(K,psi,{"Cutoff=",0.,"Maxm=",100});
     psi /= norm(psi);
 
-    auto Hpsi = applyMPO(H,psi,{"Cutoff=",1E-13,"Maxm=",5000,"Method=","Fit","Normalize=",false,"Sweeps=",100});
+    auto Hpsi = applyMPO(H,psi,{"Method=",method,"Cutoff=",1E-13,"Maxm=",5000,"Sweeps=",100});
 
-    CHECK_CLOSE(overlap(Hpsi,H,psi),overlap(Hpsi,Hpsi));
+    CHECK_CLOSE(checkMPOProd(Hpsi,H,psi),0.);
+
+    // Now with a trial starting state
+    auto Hpsi_2 = applyMPO(H,psi,Hpsi,{"Method=",method,"Cutoff=",1E-13,"Maxm=",5000,"Sweeps=",100});
+
+    CHECK_CLOSE(checkMPOProd(Hpsi_2,H,psi),0.);
 
     }
 


### PR DESCRIPTION
1. I added an extra applyMPO method where a user can input a starting guess for the output wavefunction (as we discussed, this only works for "Fit" and throws an error for "DensityMatrix". Also, the guess wavefunction is not overwritten)
2. The "DensityMatrix" method did not have an option to normalize the output wavefunction, so I added that for consistency with the "Fit" method
3. I changed the default of applyMPO to not normalize the output wavefunction