### PR TITLE
extension of svd routine to include solver ?gesdd from lapack

### DIFF
--- a/itensor/Makefile
+++ b/itensor/Makefile
@@ -14,6 +14,7 @@ SOURCES+= tensor/lapack_wrap.cc
 SOURCES+= tensor/vec.cc 
 SOURCES+= tensor/mat.cc 
 SOURCES+= tensor/gemm.cc 
+SOURCES+= tensor/extra-svds.cc
 SOURCES+= tensor/algs.cc 
 SOURCES+= tensor/contract.cc 
 SOURCES+= itdata/dense.cc 
@@ -92,7 +93,7 @@ endif
 endif
 
 touch_all_headers:
-	@touch all.h
+	@touch all.h extra-svds.h
 	@touch all_basic.h
 	@touch all_mps.h
 
@@ -123,7 +124,10 @@ tensor/mat.o: $(GDEPHEADERS)
 .debug_objs/tensor/mat.o: $(GDEPHEADERS)
 tensor/gemm.o: $(GDEPHEADERS)
 .debug_objs/tensor/gemm.o: $(GDEPHEADERS)
-GDEPHEADERS+= tensor/slicemat.h tensor/algs.h tensor/algs_impl.h
+GDEPHEADERS+= tensor/slicemat.h tensor/extra-svds.h
+tensor/extra-svds.o: $(GDEPHEADERS)
+.debug_objs/tensor/extra-svds.o: $(GDEPHEADERS)
+GDEPHEADERS+= tensor/slicemat.h tensor/algs.h tensor/algs_impl.h 
 tensor/algs.o: $(GDEPHEADERS)
 .debug_objs/tensor/algs.o: $(GDEPHEADERS)
 GDEPHEADERS+= tensor/permutation.h tensor/slicerange.h tensor/sliceten.h \

--- a/itensor/svd.cc
+++ b/itensor/svd.cc
@@ -57,7 +57,7 @@ svdImpl(ITensor const& A,
     Vector DD;
 
     TIMER_START(6)
-    SVD(M,UU,DD,VV,thresh);
+    SVD(M,UU,DD,VV,args);
     TIMER_STOP(6)
 
     //conjugate VV so later we can just do
@@ -190,7 +190,7 @@ svdImpl(IQTensor A,
         auto& VV = Vmats.at(b);
         auto& d =  dvecs.at(b);
 
-        SVD(M,UU,d,VV,thresh);
+        SVD(M,UU,d,VV,args);
 
         //conjugate VV so later we can just do
         //U*D*V to reconstruct ITensor A:

--- a/itensor/tensor/algs.h
+++ b/itensor/tensor/algs.h
@@ -6,6 +6,7 @@
 #define __ITENSOR_MATRIX_ALGS__H_
 
 #include "itensor/tensor/slicemat.h"
+#include "itensor/util/args.h"
 
 namespace itensor {
 
@@ -104,6 +105,21 @@ SVD(MatM && M,
     VecD && D, 
     MatV && V,
     Real thresh = SVD_THRESH);
+
+template<class MatM, class MatU,class VecD,class MatV,
+         class = stdx::require<
+         hasMatRange<MatM>,
+         hasMatRange<MatU>,
+         hasVecRange<VecD>,
+         hasMatRange<MatV>
+         >>
+void
+SVD(MatM && M,
+    MatU && U, 
+    VecD && D, 
+    MatV && V,
+    Args const& args);
+    //Real thresh = SVD_THRESH);
 
 
 } //namespace itensor

--- a/itensor/tensor/algs_impl.h
+++ b/itensor/tensor/algs_impl.h
@@ -155,7 +155,28 @@ SVDRef(MatRefc<T> const& M,
        MatRef<T>  const& U, 
        VectorRef  const& D, 
        MatRef<T>  const& V,
-       Real thresh);
+       Args const& args);
+
+template<class MatM, 
+         class MatU,
+         class VecD,
+         class MatV,
+         class>
+void
+SVD(MatM && M,
+    MatU && U, 
+    VecD && D, 
+    MatV && V,
+    Args const& args)
+    {
+    auto Mr = nrows(M),
+         Mc = ncols(M);
+    auto nsv = std::min(Mr,Mc);
+    resize(U,Mr,nsv);
+    resize(V,Mc,nsv);
+    resize(D,nsv);
+    SVDRef(makeRef(M),makeRef(U),makeRef(D),makeRef(V),args);
+    }
 
 template<class MatM, 
          class MatU,
@@ -175,7 +196,7 @@ SVD(MatM && M,
     resize(U,Mr,nsv);
     resize(V,Mc,nsv);
     resize(D,nsv);
-    SVDRef(makeRef(M),makeRef(U),makeRef(D),makeRef(V),thresh);
+    SVDRef(makeRef(M),makeRef(U),makeRef(D),makeRef(V),{"SVDThreshold",thresh});
     }
 
 } //namespace itensor

--- a/itensor/tensor/extra-svds.cc
+++ b/itensor/tensor/extra-svds.cc
@@ -1,0 +1,156 @@
+#include "itensor/tensor/extra-svds.h"
+
+namespace itensor {
+
+template<>
+void
+SVD_gesdd_impl(
+            MatRefc<Real> const& M,
+            MatRef<Real>  const& U, 
+            VectorRef  const& D, 
+            MatRef<Real>  const& V)
+{
+    auto Mr = nrows(M), 
+         Mc = ncols(M);
+
+    if(Mr > Mc)
+        {
+        SVD_gesdd_impl(transpose(M),V,D,U);
+        conjugate(V);
+        conjugate(U);
+#ifdef CHKSVD
+        checksvd(M,U,D,V);
+#endif
+        return;
+        }
+
+#ifdef DEBUG
+    if(!(nrows(U)==Mr && ncols(U)==Mr)) 
+        throw std::runtime_error("SVD (ref version), wrong size of U");
+    if(!(nrows(V)==Mc && ncols(V)==Mr)) 
+        throw std::runtime_error("SVD (ref version), wrong size of V");
+    if(D.size()!=Mr)
+        throw std::runtime_error("SVD (ref version), wrong size of D");
+#endif
+    
+    auto pA = M.data();
+    std::vector<Real> cpA;
+    cpA.resize(Mr*Mc);
+    
+    // LAPACK ?gesdd will read input matrix in column-major order. If we actually
+    // want to perform SVD of M**T where M is stored in column-major, we have to pass
+    // M**T stored in column-major. Copy of inpput matrix has to be done in any case, 
+    // since input matrix is destroyed in ?gesdd
+    if(isTransposed(M)) {
+        for (unsigned int i=0; i<cpA.size(); i++, pA++) cpA[(i%Mc)*Mr + i/Mc] = *pA;
+    } else {
+        std::copy(pA,pA+Mr*Mc,cpA.data());
+    }
+
+    int info;
+    dgesdd_wrapper('S', //char* specifying how much of U, V to compute
+                        //choosing *jobz=='S' computes min(m,n) cols of U, V
+        Mr,             //number of rows of input matrix *A
+        Mc,             //number of cols of input matrix *A
+        cpA.data(),     
+        D.data(),       //on return, singular values of A
+        U.data(),       //on return, unitary matrix U
+        V.data(),       //on return, unitary matrix V transpose
+        &info
+    );
+
+    // from ?gesdd:
+    // if JOBZ = 'S', V contains the first min(M=Mr,N=Mc) rows of
+    // V**T (the right singular vectors, stored rowwise); 
+    // Lapack stores V in column-major format, while the return of this function
+    // expects row-major format of V, hence the V is reordered accordingly
+    auto ncV = const_cast<Real*>(V.data()); 
+    auto pV  = reinterpret_cast<Real*>(ncV);
+
+    int l = std::min(Mr,Mc);
+    std::vector<Real> vt(l*Mc);
+    std::copy(V.data(), V.data()+l*Mc, vt.data());
+    for (unsigned int i=0; i<vt.size(); i++, pV++) *pV = vt[(i%Mc)*l + i/Mc];
+    
+#ifdef CHKSVD
+	checksvd(M,U,D,V);
+#endif
+
+    return;
+}
+
+
+template<>
+void
+SVD_gesdd_impl(
+            MatRefc<Cplx> const& M,
+            MatRef<Cplx>  const& U, 
+            VectorRef  const& D, 
+            MatRef<Cplx>  const& V)
+{
+    auto Mr = nrows(M), 
+         Mc = ncols(M);
+
+    std::cout<<"R: "<< Mr <<" Mc: "<< Mc << " M**T: "<< isTransposed(M) <<std::endl;
+
+    if(Mr > Mc)
+        {
+        SVD_gesdd_impl(transpose(M),V,D,U);
+        conjugate(V);
+        conjugate(U);
+#ifdef CHKSVD
+        checksvd(M,U,D,V);
+#endif
+        return;
+        }
+
+#ifdef DEBUG
+    if(!(nrows(U)==Mr && ncols(U)==Mr)) 
+        throw std::runtime_error("SVD (ref version), wrong size of U");
+    if(!(nrows(V)==Mc && ncols(V)==Mr)) 
+        throw std::runtime_error("SVD (ref version), wrong size of V");
+    if(D.size()!=Mr)
+        throw std::runtime_error("SVD (ref version), wrong size of D");
+#endif
+
+    auto pA = M.data();
+    std::vector<Cplx> cpA;
+    cpA.resize(Mr*Mc);
+    
+    if(isTransposed(M)) {
+        for (unsigned int i=0; i<cpA.size(); i++, pA++) cpA[(i%Mc)*Mr + i/Mc] = *pA;
+    } else {
+        std::copy(pA,pA+Mr*Mc,cpA.data());
+    }    
+
+    int info;
+    zgesdd_wrapper('S', //char* specifying how much of U, V to compute
+                        //choosing *jobz=='S' computes min(m,n) cols of U, V
+        Mr,             //number of rows of input matrix *A
+        Mc,             //number of cols of input matrix *A
+        cpA.data(),
+        D.data(),       //on return, singular values of A
+        U.data(),       //on return, unitary matrix U
+        V.data(),       //on return, unitary matrix V transpose
+        &info
+    );
+
+    // In addition to column-major to row-major reordering, also complex conjugate
+    // is taken
+    auto ncV = const_cast<Cplx*>(V.data()); 
+    auto pV  = reinterpret_cast<Cplx*>(ncV);
+
+    int l = std::min(Mr,Mc);
+    std::vector<Cplx> vt(l*Mc); 
+    std::copy(V.data(), V.data()+l*Mc, vt.data());
+    for (auto & e : vt) e = std::conj(e);
+    for (unsigned int i=0; i<vt.size(); i++, pV++) *pV = vt[(i%Mc)*l + i/Mc];
+
+#ifdef CHKSVD
+    checksvd(M,U,D,V);
+#endif
+
+    return;
+}
+
+}

--- a/itensor/tensor/extra-svds.h
+++ b/itensor/tensor/extra-svds.h
@@ -1,0 +1,22 @@
+#ifndef __ITENSOR_EXTRA_SVD_ALGS_IMPL_H_
+#define __ITENSOR_EXTRA_SVD_ALGS_IMPL_H_
+
+#include "itensor/tensor/lapack_wrap.h"
+#include "itensor/tensor/slicemat.h"
+#include "itensor/tensor/algs.h"
+#include "itensor/util/range.h"
+#include "itensor/global.h"
+
+namespace itensor {
+
+template<typename T>
+void
+SVD_gesdd_impl(
+		   	MatRefc<T> const& M,
+           	MatRef<T>  const& U, 
+           	VectorRef  const& D, 
+           	MatRef<T>  const& V);
+
+}
+
+#endif

--- a/itensor/tensor/lapack_wrap.cc
+++ b/itensor/tensor/lapack_wrap.cc
@@ -349,30 +349,61 @@ dscal_wrapper(LAPACK_INT N,
     }
 
 void 
-zgesdd_wrapper(char *jobz,           //char* specifying how much of U, V to compute
+zgesdd_wrapper(char jobz,           //char* specifying how much of U, V to compute
                                      //choosing *jobz=='S' computes min(m,n) cols of U, V
-               LAPACK_INT *m,        //number of rows of input matrix *A
-               LAPACK_INT *n,        //number of cols of input matrix *A
-               LAPACK_COMPLEX *A,    //contents of input matrix A
+               LAPACK_INT m,        //number of rows of input matrix *A
+               LAPACK_INT n,        //number of cols of input matrix *A
+               Cplx *A,    //contents of input matrix A
                LAPACK_REAL *s,       //on return, singular values of A
-               LAPACK_COMPLEX *u,    //on return, unitary matrix U
-               LAPACK_COMPLEX *vt,   //on return, unitary matrix V transpose
+               Cplx *u,    //on return, unitary matrix U
+               Cplx *vt,   //on return, unitary matrix V transpose
                LAPACK_INT *info)
     {
+    // auto ncA = const_cast<Cplx*>(A); 
+    auto pA = reinterpret_cast<LAPACK_COMPLEX*>(A);
+    auto pU = reinterpret_cast<LAPACK_COMPLEX*>(u);
+    auto pVt = reinterpret_cast<LAPACK_COMPLEX*>(vt);
     std::vector<LAPACK_COMPLEX> work;
     std::vector<LAPACK_REAL> rwork;
     std::vector<LAPACK_INT> iwork;
-    LAPACK_INT l = std::min(*m,*n),
-               g = std::max(*m,*n);
+    LAPACK_INT l = std::min(m,n),
+               g = std::max(m,n);
     LAPACK_INT lwork = l*l+2*l+g+100;
     work.resize(lwork);
     rwork.resize(5*l*(1+l));
     iwork.resize(8*l);
 #ifdef PLATFORM_acml
     LAPACK_INT jobz_len = 1;
-    F77NAME(zgesdd)(jobz,m,n,A,m,s,u,m,vt,n,work.data(),&lwork,rwork.data(),iwork.data(),info,jobz_len);
+    F77NAME(zgesdd)(&jobz,&m,&n,pA,&m,s,pU,&m,pVt,&l,work.data(),&lwork,rwork.data(),iwork.data(),info,jobz_len);
 #else
-    F77NAME(zgesdd)(jobz,m,n,A,m,s,u,m,vt,n,work.data(),&lwork,rwork.data(),iwork.data(),info);
+    F77NAME(zgesdd)(&jobz,&m,&n,pA,&m,s,pU,&m,pVt,&l,work.data(),&lwork,rwork.data(),iwork.data(),info);
+#endif
+    }
+
+void 
+dgesdd_wrapper(char jobz,           //char* specifying how much of U, V to compute
+                                    //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT m,        //number of rows of input matrix *A
+               LAPACK_INT n,        //number of cols of input matrix *A
+               LAPACK_REAL *A,      //contents of input matrix A
+               LAPACK_REAL *s,      //on return, singular values of A
+               LAPACK_REAL *u,           //on return, unitary matrix U
+               LAPACK_REAL *vt,          //on return, unitary matrix V transpose
+               LAPACK_INT *info)
+    {
+    auto pA = reinterpret_cast<LAPACK_REAL*>(A);
+    std::vector<LAPACK_REAL> work;
+    std::vector<LAPACK_INT> iwork;
+    LAPACK_INT l = std::min(m,n),
+               g = std::max(m,n);
+    LAPACK_INT lwork = l*(6 + 4*l) + g;
+    work.resize(lwork);
+    iwork.resize(8*l);
+#ifdef PLATFORM_acml
+    LAPACK_INT jobz_len = 1;
+    F77NAME(dgesdd)(&jobz,&m,&n,pA,&m,s,u,&m,vt,&l,work.data(),&lwork,iwork.data(),info,jobz_len);
+#else
+    F77NAME(dgesdd)(&jobz,&m,&n,pA,&m,s,u,&m,vt,&l,work.data(),&lwork,iwork.data(),info);
 #endif
     }
 

--- a/itensor/tensor/lapack_wrap.h
+++ b/itensor/tensor/lapack_wrap.h
@@ -297,6 +297,16 @@ void F77NAME(zgesdd)(char *jobz, LAPACK_INT *m, LAPACK_INT *n, LAPACK_COMPLEX *a
              LAPACK_COMPLEX *work, LAPACK_INT *lwork, double *rwork, LAPACK_INT *iwork, LAPACK_INT *info);
 #endif
 
+#ifdef PLATFORM_acml
+void F77NAME(dgesdd)(char *jobz, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
+             double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
+             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info, int jobz_len);
+#else
+void F77NAME(dgesdd)(char *jobz, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
+             double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
+             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info);
+#endif
+
 void F77NAME(dgeqrf)(LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, 
                      double *tau, double *work, LAPACK_INT *lwork, LAPACK_INT *info);
 
@@ -481,15 +491,27 @@ dscal_wrapper(LAPACK_INT N,
               LAPACK_INT inc = 1);
 
 void
-zgesdd_wrapper(char *jobz,           //char* specifying how much of U, V to compute
+zgesdd_wrapper(char jobz,           //char* specifying how much of U, V to compute
                                      //choosing *jobz=='S' computes min(m,n) cols of U, V
-               LAPACK_INT *m,        //number of rows of input matrix *A
-               LAPACK_INT *n,        //number of cols of input matrix *A
-               LAPACK_COMPLEX *A,    //contents of input matrix A
+               LAPACK_INT m,        //number of rows of input matrix *A
+               LAPACK_INT n,        //number of cols of input matrix *A
+               Cplx *A,    //contents of input matrix A
                LAPACK_REAL *s,       //on return, singular values of A
-               LAPACK_COMPLEX *u,    //on return, unitary matrix U
-               LAPACK_COMPLEX *vt,   //on return, unitary matrix V transpose
+               Cplx *u,    //on return, unitary matrix U
+               Cplx *vt,   //on return, unitary matrix V transpose
                LAPACK_INT *info);
+
+void
+dgesdd_wrapper(char jobz,           //char* specifying how much of U, V to compute
+                                    //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT m,       //number of rows of input matrix *A
+               LAPACK_INT n,       //number of cols of input matrix *A
+               LAPACK_REAL *A,       //contents of input matrix A
+               LAPACK_REAL *s,       //on return, singular values of A
+               LAPACK_REAL *u,       //on return, unitary matrix U
+               LAPACK_REAL *vt,      //on return, unitary matrix V transpose
+               LAPACK_INT *info);
+
 
 //
 // dgeqrf

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -24,6 +24,7 @@ SOURCES+= qn_test.cc
 SOURCES+= iqindex_test.cc
 SOURCES+= iqtensor_test.cc
 SOURCES+= decomp_test.cc
+SOURCES+= extra-svds_test.cc
 SOURCES+= mps_test.cc
 SOURCES+= mpo_test.cc
 SOURCES+= autompo_test.cc

--- a/unittest/extra-svds_test.cc
+++ b/unittest/extra-svds_test.cc
@@ -1,0 +1,191 @@
+#include "test.h"
+#include "itensor/decomp.h"
+#include "itensor/util/print_macro.h"
+
+using namespace itensor;
+using namespace std;
+
+TEST_CASE("Additional SVD implementation Tests")
+{
+
+SECTION("dgesdd test")
+    {
+    Index K  = Index("k",5);
+    Index Kp = prime(K);
+
+    ITensor A(K,Kp);
+    A.set(K(1),Kp(1), 6.80);
+    A.set(K(1),Kp(2),-6.05);
+    A.set(K(1),Kp(3),-0.45);
+    A.set(K(1),Kp(4), 8.32);
+    A.set(K(1),Kp(5),-9.67); 
+
+    A.set(K(2),Kp(1),-2.11);
+    A.set(K(2),Kp(2),-3.30);
+    A.set(K(2),Kp(3), 2.58);
+    A.set(K(2),Kp(4), 2.71);
+    A.set(K(2),Kp(5),-5.14); 
+
+    A.set(K(3),Kp(1), 5.66);
+    A.set(K(3),Kp(2), 5.36);
+    A.set(K(3),Kp(3),-2.70);
+    A.set(K(3),Kp(4), 4.35);
+    A.set(K(3),Kp(5),-7.26); 
+
+    A.set(K(4),Kp(1), 5.97);
+    A.set(K(4),Kp(2),-4.44);
+    A.set(K(4),Kp(3), 0.27);
+    A.set(K(4),Kp(4),-7.17);
+    A.set(K(4),Kp(5), 6.08); 
+
+    A.set(K(5),Kp(1), 8.23);
+    A.set(K(5),Kp(2), 1.08);
+    A.set(K(5),Kp(3), 9.04);
+    A.set(K(5),Kp(4), 2.14);
+    A.set(K(5),Kp(5),-6.87); 
+
+    ITensor U(Kp),D,V;
+
+    svd(A,U,D,V,{"SVDMethod","gesdd","Truncate",false});
+
+    CHECK(norm(A-U*D*V) < 1E-12);
+    }
+
+SECTION("zgesdd test")
+    {
+    Index m = Index("m",3);
+    Index n = Index("n",4);
+
+    ITensor A(m,n);
+    A.set(m(1),n(1),-5.40+7.40_i);
+    A.set(m(1),n(2), 6.00+6.38_i);
+    A.set(m(1),n(3), 9.91+0.16_i);
+    A.set(m(1),n(4),-5.28-4.16_i);
+
+    A.set(m(2),n(1), 1.09+1.55_i);
+    A.set(m(2),n(2), 2.60+0.07_i);
+    A.set(m(2),n(3), 3.98-5.26_i);
+    A.set(m(2),n(4), 2.03+1.11_i);
+
+    A.set(m(3),n(1), 9.88+1.91_i);
+    A.set(m(3),n(2), 4.92+6.31_i);
+    A.set(m(3),n(3),-2.11+7.39_i);
+    A.set(m(3),n(4),-9.81-8.98_i);
+
+    ITensor U(m),D,V;
+
+    svd(A,U,D,V,{"SVDMethod","gesdd","Truncate",false});
+
+    CHECK(norm(A-U*D*V) < 1E-12);
+    }
+
+SECTION("Transpose dgesdd SVD")
+    {
+    Index a("a",3),
+          b("b",2);
+
+    ITensor A(a,b);
+
+    A.set(a(1),b(1),1);
+    A.set(a(2),b(1),2);
+    A.set(a(3),b(1),3);
+    A.set(a(1),b(2),4);
+    A.set(a(2),b(2),5);
+    A.set(a(3),b(2),6);
+
+    ITensor U(b),D,V;
+    svd(A,U,D,V,{"SVDMethod","gesdd","Truncate",false});
+
+    CHECK(norm(A-U*D*V) < 1E-12);
+    }
+
+SECTION("dgesdd SVD")
+    {
+    Index i("i",2),
+          j("j",3),
+          k("k",4),
+          l("l",5);
+
+    SECTION("Case 1")
+        {
+        auto T = randomTensor(i,j,k);
+
+        ITensor U(i,j),D,V;
+
+        svd(T,U,D,V,{"SVDMethod","gesdd"});
+
+        CHECK(norm(T-U*D*V) < 1E-12);
+        CHECK(hasindex(U,i));
+        CHECK(hasindex(U,j));
+        CHECK(hasindex(V,k));
+        }
+
+    SECTION("Case 2")
+        {
+        auto T = randomTensor(i,j,k);
+
+        ITensor U(i,k),D,V;
+        svd(T,U,D,V,{"SVDMethod","gesdd"});
+        CHECK(norm(T-U*D*V) < 1E-12);
+        CHECK(hasindex(U,i));
+        CHECK(hasindex(U,k));
+        CHECK(hasindex(V,j));
+        }
+
+    SECTION("Case 3")
+        {
+        auto T = randomTensor(i,k,prime(i));
+
+        ITensor U(i,prime(i)),D,V;
+        svd(T,U,D,V,{"SVDMethod","gesdd"});
+        CHECK(norm(T-U*D*V) < 1E-12);
+        CHECK(hasindex(U,i));
+        CHECK(hasindex(U,prime(i)));
+        CHECK(hasindex(V,k));
+        }
+
+    }
+
+SECTION("IQTensor dgesdd SVD")
+    {
+
+    SECTION("Regression Test 1")
+        {
+        //Oct 5, 2015: was encountering a 
+        //bad memory access bug with this code
+        IQIndex u("u",Index{"u+2",1},QN(+2),
+                      Index{"u00",1},QN( 0),
+                      Index{"u-2",1},QN(-2));
+        IQIndex v("v",Index{"v+2",1},QN(+2),
+                      Index{"v00",1},QN( 0),
+                      Index{"v-2",1},QN(-2));
+
+        auto S = randomTensor(QN(),u,v);
+        IQTensor U(u),D,V;
+        svd(S,U,D,V,{"SVDMethod","gesdd"});
+
+        CHECK(norm(S-U*D*V) < 1E-12);
+        }
+
+    SECTION("Regression Test 2")
+        {
+        //Feb 10, 2016: code that fixes sign of
+        //singular values to be positive was broken
+		auto s1 = IQIndex("s1",Index("s1+",1,Site),QN(+1),Index("s1-",1,Site),QN(-1));
+		auto s2 = IQIndex("s2",Index("s2+",1,Site),QN(+1),Index("s2-",1,Site),QN(-1));
+		auto sing = IQTensor(s1,s2);
+		sing.set(s1(1),s2(2), 1./sqrt(2));
+		sing.set(s1(2),s2(1),-1./sqrt(2));
+		auto prod = IQTensor(s1,s2);
+		prod.set(s1(1),s2(2),1.);
+		auto psi = sing*sin(0.1)+prod*cos(0.1);
+		psi /= norm(psi);
+        psi.scaleTo(-1.);
+		IQTensor A(s1),D,B;
+		svd(psi,A,D,B,{"SVDMethod","gesdd"});
+        CHECK(norm(psi-A*D*B) < 1E-12);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This is initial commit for extension of svd solver as implemented in ITensor. User can
pass a parameter to svd function inside Args container specifying method to use.

an example call: svd(A,U,V,D,{"SVDMethod","gesdd"})

if Args do not contain "SVDMethod" parameter, the default ITensor implementation of svd
solver is used. No change to calls of svd already defined anywhere in the code is necessary.

The extension is implemented at low level. A function SVDRef (defined in tensor/algs.cc) 
serves as a fork. It checks for a presence of "SVDMethod" parameter in the Args. If not
found a default ITensor svd is called. Otherwise, a particular implementation identified
through string, in this case "gesdd" is called. The actual implementation of the solver
is given in a file tensor/extra-svds.cc. It performs the call to lapack ?gesdd routine.

The unit tests are included in file unittests/extra-svds_test.cc    