### PR TITLE
New random MPO constructor

### DIFF
--- a/itensor/mps/mpo.h
+++ b/itensor/mps/mpo.h
@@ -45,6 +45,14 @@ class MPOt : private MPSt<Tensor>
     MPOt(SiteSet const& sites, 
          Real _refNorm = DefaultLogRefScale);
 
+    MPOt(SiteSet const& sites, 
+         std::vector<int> const& bondList,
+         const Args& args = Args::global());
+
+    MPOt(SiteSet const& sites, 
+         int k,
+         const Args& args = Args::global());
+
     explicit operator bool() const { return Parent::operator bool(); }
 
     using Parent::N;
@@ -457,6 +465,18 @@ void
 putMPOLinks(MPO& W, Args const& args = Args::global());
 void
 putMPOLinks(IQMPO& W, Args const& args = Args::global());
+
+//fill an MPO with random tensors with dimensions specified in bondList
+void 
+fillRandomMPO(MPO& W, 
+              const SiteSet& sites,
+              std::vector<int> const& bondList, 
+              Args const& args = Args::global());
+/*void 
+fillRandomMPO(IQMPO& W, 
+              const SiteSet& sites,
+              std::vector<int>& bondList, 
+              Args const& args = Args::global());*/
 
 template <class Tensor>
 std::ostream& 

--- a/unittest/mpo_test.cc
+++ b/unittest/mpo_test.cc
@@ -408,5 +408,34 @@ SECTION("nmultMPO")
         CHECK_DIFF(oR,oKH,1E-5);
         }
     }
+SECTION("Random MPOs")
+      {
+      auto sites = SpinHalf(6);
+      /* create an MPO with a random tensor on every site with dimension k on every bond
+       * optional argument "Orthogonalize":true in order to 
+       * automatically orthogonalize after creation
+       */
+      int k = 2;
+      auto H1 = MPO(sites,k);
 
+      auto OrthoH1 = MPO(sites,k,{"Orthogonalize",true}); 
+
+      /* create an MPO with a random tensor on every site 
+       * with each bond dimension specified by a vector
+       */
+      std::vector<int> bondList = {2,3,5,3,2};
+      auto H2 = MPO(sites,bondList);
+      //bonds directly from initializer list
+      auto H3 = MPO(sites,{3,3,3,3,3},{"Orthogonalize",true,"Scale",0.2});
+      
+      CHECK_EQUAL(maxM(H1),2);
+      CHECK_EQUAL(maxM(H2),5);
+      CHECK_EQUAL(maxM(H3),3);
+      CHECK_CLOSE(averageM(H1),2);
+      CHECK_CLOSE(averageM(H2),3);
+      CHECK_CLOSE(averageM(H3),3);
+      REQUIRE_NOTHROW(overlap(OrthoH1,OrthoH1));
+      REQUIRE_NOTHROW(overlap(H2,H2));
+      REQUIRE_NOTHROW(overlap(H3,H3));
+      }
 }


### PR DESCRIPTION
I would like to propose the following interface to create random MPOs directly rather than the AutoMPO method. 
```c++
/* create an MPO with a random tensor on every site with uniform dimension k on Link bonds
 * optional argument "Orthogonalize":true in order to 
 * automatically orthogonalize after creation
 * and "Scale" which does Aref(j)*=scale
 */
int k = 2;
auto H1 = MPO(sites,k);

auto OrthoH = MPO(sites,k,{"Orthogonalize",true}); 

/* create an MPO with a random tensor on every site 
 * with each Link bond dimension specified by a vector
 */
std::vector<int> bondList = {2,3,5,3,2};
auto H2 = MPO(sites,bondList);
//can create directly in constructor
auto H3 = MPO(sites,{2,2,2,2,2},{"Orthogonalize",true,"Scale",0.2});

```
I have only implemented a non-QN version as I'm not sure what a QN one should look like. If anyone has comments/suggestions I'd be happy to implement it!