### PR TITLE
.real() and .cplx() can take vector<IndexVal> and vector<int>

### DIFF
--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -100,10 +100,18 @@ class ITensorT
     Real
     real(IndexVals&&... ivs) const;
 
+    Cplx
+    cplx(std::vector<indexval_type> const& ivs) const;
+
     template <typename IV, typename... IVs>
     auto
     cplx(IV const& iv1, IVs&&... ivs) const
          -> stdx::if_compiles_return<Cplx,decltype(iv1.index),decltype(iv1.val)>;
+
+    template <typename Int>
+    auto
+    cplx(std::vector<Int> const& ints) const
+        -> stdx::enable_if_t<std::is_integral<Int>::value,Cplx>;
 
     template <typename Int, typename... Ints>
     auto

--- a/unittest/iqtensor_test.cc
+++ b/unittest/iqtensor_test.cc
@@ -1278,30 +1278,42 @@ for(auto kk : range1(k.m()))
 }
 
 SECTION("Set and Get with int")
-{
-auto I = IQIndex("I",Index("I+",1),QN(+1),
-                     Index("I-",1),QN(-1));
-auto J = IQIndex("J",Index("I+",2),QN(+1),
-                     Index("I-",2),QN(-1));
-auto T = IQTensor(I,J);
-T.set(2,1,21);
-CHECK_CLOSE(T.real(J(1),I(2)),21);
-CHECK_CLOSE(T.real(2,1),21);
-}
+    {
+    auto I = IQIndex("I",Index("I+",1),QN(+1),
+                         Index("I-",1),QN(-1));
+    auto J = IQIndex("J",Index("I+",2),QN(+1),
+                         Index("I-",2),QN(-1));
+    auto T = IQTensor(I,J);
+    T.set(2,1,21);
+    CHECK_CLOSE(T.real(J(1),I(2)),21);
+    CHECK_CLOSE(T.real(2,1),21);
+    }
+
+SECTION("Set and Get with vector<int>")
+    {
+    auto I = IQIndex("I",Index("I+",1),QN(+1),
+                         Index("I-",1),QN(-1));
+    auto J = IQIndex("J",Index("I+",2),QN(+1),
+                         Index("I-",2),QN(-1));
+    auto T = IQTensor(I,J);
+    T.set(vector<int>({2,1}),21);
+    CHECK_CLOSE(T.real(vector<IQIndexVal>({J(1),I(2)})),21);
+    CHECK_CLOSE(T.real(vector<int>({2,1})),21);
+    }
 
 SECTION("Set and Get with long int")
-{
-auto I = IQIndex("I",Index("I+",1),QN(+1),
-                     Index("I-",1),QN(-1));
-auto J = IQIndex("J",Index("I+",2),QN(+1),
-                     Index("I-",2),QN(-1));
-auto T = IQTensor(I,J);
-long int i1 = 1,
-         i2 = 2;
-T.set(i2,i1,21);
-CHECK_CLOSE(T.real(J(1),I(2)),21);
-CHECK_CLOSE(T.real(i2,i1),21);
-}
+    {
+    auto I = IQIndex("I",Index("I+",1),QN(+1),
+                         Index("I-",1),QN(-1));
+    auto J = IQIndex("J",Index("I+",2),QN(+1),
+                         Index("I-",2),QN(-1));
+    auto T = IQTensor(I,J);
+    long int i1 = 1,
+             i2 = 2;
+    T.set(i2,i1,21);
+    CHECK_CLOSE(T.real(J(1),I(2)),21);
+    CHECK_CLOSE(T.real(i2,i1),21);
+    }
 
 SECTION("Reindex")
     {

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -380,10 +380,10 @@ T.set(1,i2,12);
 T.set(i2,1,21);
 T.set(i2,2,22);
 CHECK(!isComplex(T));
-CHECK_CLOSE(T.real(s1(1),s2(1)),11);
-CHECK_CLOSE(T.real(s1(1),s2(2)),12);
-CHECK_CLOSE(T.real(s1(2),s2(1)),21);
-CHECK_CLOSE(T.real(s1(2),s2(2)),22);
+CHECK_CLOSE(T.real(s1(i1),s2(i1)),11);
+CHECK_CLOSE(T.real(s1(i1),s2(2)),12);
+CHECK_CLOSE(T.real(s1(2),s2(i1)),21);
+CHECK_CLOSE(T.real(s1(i2),s2(2)),22);
 CHECK_CLOSE(T.real(i1,i1),11);
 CHECK_CLOSE(T.real(i1,2),12);
 CHECK_CLOSE(T.real(2,i1),21);
@@ -395,26 +395,30 @@ CHECK_CLOSE(T.cplx(s1(2),s2(1)),3+5_i);
 CHECK_CLOSE(T.cplx(i2,i1),3+5_i);
 }
 
-SECTION("Set Using vector<IndexVal>")
+SECTION("Set and Get Using vector<IndexVal>")
 {
 auto T = ITensor(s1,s2);
 auto v12 = vector<IndexVal>{{s2(2),s1(1)}};
 T.set(v12,12);
 auto v21 = vector<IndexVal>{{s1(2),s2(1)}};
 T.set(v21,21);
+CHECK_CLOSE(T.real(vector<IndexVal>({s1(1),s2(2)})),12);
+CHECK_CLOSE(T.real(vector<IndexVal>({s1(2),s2(1)})),21);
 CHECK_CLOSE(T.real(s1(1),s2(2)),12);
 CHECK_CLOSE(T.real(s1(2),s2(1)),21);
 }
 
-SECTION("Set Using vector<int>")
+SECTION("Set and Get Using vector<int>")
 {
 auto T = ITensor(s1,s2);
 auto v12 = vector<int>{{1,2}};
 T.set(v12,12);
 auto v21 = vector<int>{{2,1}};
 T.set(v21,21);
-CHECK_CLOSE(T.real(s1(1),s2(2)),12);
-CHECK_CLOSE(T.real(s1(2),s2(1)),21);
+CHECK_CLOSE(T.real(vector<int>({1,2})),12);
+CHECK_CLOSE(T.real(vector<int>({2,1})),21);
+CHECK_CLOSE(T.real(1,2),12);
+CHECK_CLOSE(T.real(2,1),21);
 }
 
 SECTION("IndexValConstructors")


### PR DESCRIPTION
This makes them consistent with .set(), which can take vector<IndexVal>, etc. This was suggested by Andreas on the ITensor support page.