### PR TITLE
Add IgnoreDegeneracy flag to svd, diagHermitian, and dmrg

### DIFF
--- a/itensor/decomp.cc
+++ b/itensor/decomp.cc
@@ -114,6 +114,7 @@ truncate(Vector & P,
          bool doRelCutoff,
          Args const& args)
     {
+    auto ignore_degeneracy = args.getBool("IgnoreDegeneracy",true);
     long origm = P.size();
     long n = origm-1;
     Real docut = 0;
@@ -186,9 +187,16 @@ truncate(Vector & P,
         {
         docut = (P(n+1) + P(n))/2.;
         //Check for a degeneracy:
-        if(std::fabs(P(n+1)-P(n)) < 1E-3*P(n)) 
+        if(std::fabs(P(n+1)-P(n)) < 1E-3*P(n))
             {
-            docut += 1E-3*P(n);
+            if(ignore_degeneracy)
+                {
+                docut -= 1E-3*P(n);
+                }
+            else
+                {
+                docut += 1E-3*P(n);
+                }
             }
         }
 

--- a/itensor/hermitian.cc
+++ b/itensor/hermitian.cc
@@ -40,6 +40,7 @@ diagHImpl(ITensor H,
     auto do_truncate = args.getBool("Truncate",def_do_trunc);
     auto doRelCutoff = args.getBool("DoRelCutoff",true);
     auto absoluteCutoff = args.getBool("AbsoluteCutoff",false);
+    auto ignore_degeneracy = args.getBool("IgnoreDegeneracy",true);
     auto showeigs = args.getBool("ShowEigs",false);
     auto iname = args.getString("IndexName","d");
 
@@ -82,7 +83,22 @@ diagHImpl(ITensor H,
         {
         //if(DD(1) < 0) DD *= -1; //DEBUG
         tie(truncerr,docut) = truncate(DD,maxm,minm,cutoff,absoluteCutoff,doRelCutoff,args);
-        m = DD.size();
+        if(ignore_degeneracy)
+            {
+            m = DD.size();
+            }
+        else
+            {
+            long total_m = 0;
+            for(decltype(DD.size()) n = 0; n < DD.size() && DD(n) > docut; ++n)
+                {
+                total_m += 1;
+                }
+            m = total_m;
+            }
+#ifdef DEBUG
+        if(m==0) throw std::runtime_error("Index of D after diagHermitian is empty. Consider raising Maxm or Cutoff, or making IgnoreDegeneracy true");
+#endif
         reduceCols(UU,m);
         }
 
@@ -130,7 +146,7 @@ Spectrum
 diagHImpl(IQTensor    H, 
           IQTensor  & U, 
           IQTensor  & D,
-          Args const& args)
+          Args        args)
     {
     SCOPED_TIMER(7)
     auto cutoff = args.getReal("Cutoff",0.);
@@ -140,9 +156,12 @@ diagHImpl(IQTensor    H,
     auto do_truncate = args.getBool("Truncate",def_do_trunc);
     auto doRelCutoff = args.getBool("DoRelCutoff",true);
     auto absoluteCutoff = args.getBool("AbsoluteCutoff",false);
+    auto ignore_degeneracy = args.getBool("IgnoreDegeneracy",true);
     auto showeigs = args.getBool("ShowEigs",false);
     auto compute_qns = args.getBool("ComputeQNs",false);
     auto iname = args.getString("IndexName","d");
+
+    args.add("IgnoreDegeneracy",ignore_degeneracy);
 
     if(H.r() != 2)
         {
@@ -267,6 +286,7 @@ diagHImpl(IQTensor    H,
     IQIndex::storage iq;
     iq.reserve(Nblock);
 
+    long total_m = 0;
     for(auto b : range(Nblock))
         {
         auto& UU = Umats.at(b);
@@ -279,6 +299,10 @@ diagHImpl(IQTensor    H,
             //Truncate all elems of d falling below docut
             while(this_m > 0 && d(this_m-1) <= docut) --this_m;
             }
+        //We need to check that the number of states doesn't
+        //go above m, which can happen if there are degeneracies
+        total_m += this_m;
+        if(total_m > m) this_m -= (total_m-m);
 
         if(this_m == 0) 
             { 

--- a/itensor/mps/dmrg.h
+++ b/itensor/mps/dmrg.h
@@ -195,6 +195,7 @@ DMRGWorker(MPSt<Tensor>& psi,
     {
     const bool quiet = args.getBool("Quiet",false);
     const int debug_level = args.getInt("DebugLevel",(quiet ? 0 : 1));
+    const bool ignore_degeneracy = args.getBool("IgnoreDegeneracy",false);
 
     const int N = psi.N();
     Real energy = NAN;
@@ -202,6 +203,7 @@ DMRGWorker(MPSt<Tensor>& psi,
     psi.position(1);
 
     args.add("DebugLevel",debug_level);
+    args.add("IgnoreDegeneracy",ignore_degeneracy);
     args.add("DoNormalize",true);
     
     for(int sw = 1; sw <= sweeps.nsweep(); ++sw)

--- a/unittest/decomp_test.cc
+++ b/unittest/decomp_test.cc
@@ -153,6 +153,33 @@ SECTION("ITensor SVD")
 
     }
 
+SECTION("ITensor SVD (degeneracy test)")
+    {
+    Index i("i",3);
+    auto T = ITensor(i,prime(i));
+    T.set(1,1,1.0);
+    T.set(2,2,1.0);
+    T.set(3,3,2.0);
+
+    SECTION("Case 1: Ignore degeneracy")
+        {
+        ITensor U(i),D,V;
+        //IgnoreDegeneracy=true is the default
+        svd(T,U,D,V,{"Maxm=",2,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==2);
+        }
+
+    SECTION("Case 2: Don't ignore degeneracy")
+        {
+        ITensor U(i),D,V;
+        svd(T,U,D,V,{"Maxm=",2,"IgnoreDegeneracy=",false,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==1);
+        }
+
+    }
+
 SECTION("IQTensor SVD")
     {
 
@@ -191,6 +218,33 @@ SECTION("IQTensor SVD")
 		IQTensor A(s1),D,B;
 		svd(psi,A,D,B);
         CHECK(norm(psi-A*D*B) < 1E-12);
+        }
+
+    }
+
+SECTION("IQTensor SVD (degeneracy test)")
+    {
+    auto i = IQIndex("i",Index("i0",3),QN(0),Index("i1",2),QN(1));
+    auto A = IQTensor(i,dag(prime(i)));
+    A.set(2,2,2.0);
+    A.set(4,4,1.0);
+    A.set(5,5,1.0);
+
+    SECTION("Case 1: Ignore degeneracy")
+        {
+        IQTensor U(i),D,V;
+        // Degeneracy ignored by default
+        svd(A,U,D,V,{"Maxm=",2,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==2);
+        }
+
+    SECTION("Case 2: Don't ignore degeneracy")
+        {
+        IQTensor U(i),D,V;
+        svd(A,U,D,V,{"Maxm=",2,"IgnoreDegeneracy=",false,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==1);
         }
 
     }
@@ -295,6 +349,34 @@ SECTION("ITensor diagHermitian")
         diagHermitian(T,U,D);
         CHECK(norm(T-U*D*prime(U,4)) < 1E-12);
         }
+
+    SECTION("Ignore degeneracy")
+        {
+        Index i("i",3);
+        auto T = ITensor(i,prime(i));
+        T.set(1,1,1.0);
+        T.set(2,2,1.0);
+        T.set(3,3,2.0);
+        ITensor U(i),D;
+        //IgnoreDegeneracy=true is the default
+        diagHermitian(T,U,D,{"Maxm=",2,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==2);
+        }
+
+    SECTION("Don't ignore degeneracy")
+        {
+        Index i("i",3);
+        auto T = ITensor(i,prime(i));
+        T.set(1,1,1.0);
+        T.set(2,2,1.0);
+        T.set(3,3,2.0);
+        ITensor U(i),D;
+        diagHermitian(T,U,D,{"Maxm=",2,"IgnoreDegeneracy=",false,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==1);
+        }
+
     }
 
 SECTION("IQTensor diagHermitian")
@@ -359,6 +441,34 @@ SECTION("IQTensor diagHermitian")
         CHECK(hasindex(U,prime(I)));
         CHECK(norm(T-dag(U)*D*prime(U,3)) < 1E-12);
         }
+
+    SECTION("Ignore degeneracy")
+        {
+        auto i = IQIndex("i",Index("i0",3),QN(0),Index("i1",2),QN(1));
+        auto A = IQTensor(i,dag(prime(i)));
+        A.set(2,2,2.0);
+        A.set(4,4,1.0);
+        A.set(5,5,1.0);
+        IQTensor U(i),D;
+        // Degeneracy ignored by default
+        diagHermitian(A,U,D,{"Maxm=",2,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==2);
+        }
+
+    SECTION("Don't ignore degeneracy")
+        {
+        auto i = IQIndex("i",Index("i0",3),QN(0),Index("i1",2),QN(1));
+        auto A = IQTensor(i,dag(prime(i)));
+        A.set(2,2,2.0);
+        A.set(4,4,1.0);
+        A.set(5,5,1.0);
+        IQTensor U(i),D;
+        diagHermitian(A,U,D,{"Maxm=",2,"IgnoreDegeneracy=",false,"Cutoff=",0.0});
+        auto l = commonIndex(U,D);
+        CHECK(l.m()==1);
+        }
+
     }
 
 SECTION("Exp Hermitian")


### PR DESCRIPTION
This adds an argument "IgnoreDegeneracy" to the functions svd(), diagHermitian(), and dmrg() which allows a user to specify whether or not degeneracies in the singular value spectrum or eigenvalue spectrum are ignored when truncating.

In this pull request, "IgnoreDegeneracy" defaults to true for svd() and diagHermitian(), and defaults to false for dmrg().

I am definitely open to suggestions about the name of the flag and the defaults. With these defaults, it makes it so that simple situations like:
```c++
auto i = IQIndex("i",Index("i",2),QN(0));
auto A = IQTensor(i,dag(prime(i)));
A.set(1,1,1.0);
A.set(2,2,1.0);

IQTensor U(i),S,V;
svd(A,U,S,V,{"Maxm=",1});
```
"just work" now, i.e. truncates one of the singular values and outputs potentially random singular vectors. This case currently throws a mysterious error since it truncates the entire set of degenerate singular values (this pull request also improves the debug error message if {"IgnoreDegeneracy=",false} is added to the above args list).