### PR TITLE
Tag convention for MPS and MPO, with tests

### DIFF
--- a/itensor/decomp.h
+++ b/itensor/decomp.h
@@ -303,7 +303,8 @@ denmatDecomp(ITensor const& AA,
     //Apply combiner
     START_TIMER(8)
     //TODO: decide on a tag convention for denmatDecomp
-    auto itagset = getTagSet(args,"Tags","Link,MID");
+    auto itagset = getTagSet(args,"Tags","Link");
+    args.add("Tags",toString(itagset));
     auto cmb = combiner(std::move(cinds),{"Tags",toString(itagset)});
     auto ci = cmb.inds().front();
 

--- a/itensor/mps/autompo.cc
+++ b/itensor/mps/autompo.cc
@@ -634,7 +634,7 @@ toMPOImpl(AutoMPO const& am,
             }
         inqn.emplace_back(currq,currm);
 
-        links.at(n) = Index(move(inqn),format("Link,MPO,%d",n));
+        links.at(n) = Index(move(inqn),format("Link,l=%d",n));
         //printfln("links[%d]=\n%s",n,links[n]);
 
         //if(n <= 2 or n == N)
@@ -1163,8 +1163,8 @@ compressMPO(SiteSet const& sites,
     int d0 = isExpH ? 1 : 2;
     
     //TODO: check these are the correct tags
-    if(hasqn) links.at(0) = Index(ZeroQN,d0,format("Link,MPO,%d",0));
-    else      links.at(0) = Index(d0,format("Link,MPO,%d",0));
+    if(hasqn) links.at(0) = Index(ZeroQN,d0,format("Link,l=%d",0));
+    else      links.at(0) = Index(d0,format("Link,l=%d",0));
 
     auto max_d = links.at(0).m();
     for(int n = 1; n <= N; ++n)
@@ -1212,7 +1212,7 @@ compressMPO(SiteSet const& sites,
                 int m = ncols(V_npp[q]);
                 inqn.emplace_back(q,m);
                 }
-            links.at(n) = Index(move(inqn),format("Link,MPO,%d",n));
+            links.at(n) = Index(move(inqn),format("Link,l=%d",n));
             }
         else
             {
@@ -1223,7 +1223,7 @@ compressMPO(SiteSet const& sites,
                 if(q == ZeroQN) continue; // was already taken care of
                 m += ncols(V_npp[q]);
                 }
-            links.at(n) = Index(m,format("Link,MPO,%d",n));
+            links.at(n) = Index(m,format("Link,l=%d",n));
             }
 
         //
@@ -1559,7 +1559,7 @@ toExpH_ZW1(AutoMPO const& am,
             }
         qnsize.emplace_back(currq,currm);
 
-        links.at(n) = Index(move(qnsize),format("Link,MPO,%d",n));
+        links.at(n) = Index(move(qnsize),format("Link,l=%d",n));
 
         //if(n <= 2 or n == N)
         //    {

--- a/itensor/mps/mpoalgs.cc
+++ b/itensor/mps/mpoalgs.cc
@@ -222,7 +222,7 @@ exactApplyMPO(MPO const& K,
 
     auto rho = E.at(N-1) * O * dag(prime(O,plev));
     ITensor U,D;
-    dargs.add("Tags=",format("Link,MPO,%d",N));
+    dargs.add("Tags=",format("Link,l=%d",N-1));
     auto spec = diagHermitian(rho,U,D,dargs);
     if(verbose) printfln("  j=%02d truncerr=%.2E m=%d",N-1,spec.truncerr(),commonIndex(U,D).m());
 
@@ -246,7 +246,7 @@ exactApplyMPO(MPO const& K,
             }
         rho = E.at(j-1) * O * dag(prime(O,plev));
         //TODO: make sure this tag convention is working
-        dargs.add("Tags=",format("Link,MPO,%d",j));
+        dargs.add("Tags=",format("Link,l=%d",j-1));
         auto spec = diagHermitian(rho,U,D,dargs);
         O = O*U*psi.A(j-1)*K.A(j-1);
         O.noPrime(siteTags);
@@ -359,7 +359,7 @@ fitApplyMPO(Real fac,
                 }
 
             //TODO: does this tag the correct bond, independent of the sweep direction?
-            args.add("Tags",format("Link,MPS,%d",b));
+            args.add("Tags",format("Link,l=%d",b));
 
             auto lwfK = (BK.at(b-1) ? BK.at(b-1)*origPsi.A(b) : origPsi.A(b));
             lwfK *= K.A(b);

--- a/itensor/mps/mps.h
+++ b/itensor/mps/mps.h
@@ -111,7 +111,7 @@ class MPS
     svdBond(int b, 
             ITensor const& AA, 
             Direction dir, 
-            Args const& args = Args::global());
+            Args args = Args::global());
 
     template<class LocalOpT>
     Spectrum 
@@ -119,7 +119,7 @@ class MPS
             ITensor const& AA, 
             Direction dir, 
             LocalOpT const& PH, 
-            Args const& args = Args::global());
+            Args args = Args::global());
 
     //Move the orthogonality center to site i 
     //(leftLim() == i-1, rightLim() == i+1, orthoCenter() == i)

--- a/itensor/mps/mps_impl.h
+++ b/itensor/mps/mps_impl.h
@@ -10,7 +10,7 @@ namespace itensor {
 template <class BigMatrixT>
 Spectrum MPS::
 svdBond(int b, ITensor const& AA, Direction dir, 
-        BigMatrixT const& PH, Args const& args)
+        BigMatrixT const& PH, Args args)
     {
     setBond(b);
     if(dir == Fromleft && b-1 > leftLim())
@@ -27,6 +27,10 @@ svdBond(int b, ITensor const& AA, Direction dir,
     auto noise = args.getReal("Noise",0.);
     auto cutoff = args.getReal("Cutoff",MIN_CUT);
     auto usesvd = args.getBool("UseSVD",false);
+    auto tagset = getTagSet(args,"Tags",format("Link,l=%d",b));
+    args.add("Tags",toString(tagset));
+    if(dir == Fromleft) args.add("LeftTags",toString(tagset));
+    else                args.add("RightTags",toString(tagset));
 
     Spectrum res;
 

--- a/itensor/qn.cc
+++ b/itensor/qn.cc
@@ -318,8 +318,8 @@ operator==(QN qa, QN const& qb)
 bool
 operator<(QN const& qa, QN const& qb)
     {
-    int a = 1;
-    int b = 1;
+    size_t a = 1;
+    size_t b = 1;
     while(a <= QNSize() && b <= QNSize()
           && (isActive(qa.num(a)) || isActive(qb.num(b))))
         {

--- a/unittest/mps_test.cc
+++ b/unittest/mps_test.cc
@@ -52,6 +52,13 @@ SECTION("Constructors (m==1)")
     auto psi = MPS(shsitesQNs);
     auto l2 = commonIndex(psi.A(2),psi.A(3));
     CHECK(1==l2.m());
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shsitesQNs(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
     }
 
 SECTION("Constructors (m>1)")
@@ -60,19 +67,81 @@ SECTION("Constructors (m>1)")
     auto psi = MPS(shsites,m);
     auto l2 = commonIndex(psi.A(2),psi.A(3));
     CHECK(m==l2.m());
+
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shsites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
+
+    for(int n = 1; n <= N; ++n)
+      randomize(psi.Aref(n));
+
+    psi.position(1);
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shsites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
+
+    psi.position(N);
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shsites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
     }
 
 SECTION("Random constructors (m==1)")
     {
     auto psi = randomMPS(shsites);
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shsites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
+
     psi.position(1);
-    CHECK(norm(psi)>0);
+    auto normpsi = norm(psi);
+    CHECK(normpsi>0);
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shsites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
+
+    psi.position(N);
+    CHECK_CLOSE(normpsi,norm(psi));
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shsites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
     }
 
 SECTION("Random constructors, QN conserved (m==1)")
     {
     auto psi = randomMPS(shFerroQNs);
     CHECK(norm(psi)>0);
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(shFerroQNs(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
     }
 
 SECTION("MPSAddition 1")
@@ -88,6 +157,14 @@ SECTION("MPSAddition 1")
     //"Valence bond" between sites 1 and 2
     MPS psi = ISqrt2*sum(MPS(i1),MPS(i2));
 
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(sites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
+
     CHECK_CLOSE(norm(psi),1);
     CHECK_EQUAL(totalQN(psi),QN({"Nf",1}));
     }
@@ -98,6 +175,14 @@ SECTION("MPSAddition 2")
     auto psi1 = randomMPS(sites);
     auto psi2 = randomMPS(sites);
     auto psi = sum(psi1,psi2);
+
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(sites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
 
     CHECK_EQUAL(rank(psi.A(1)),2);
     CHECK_EQUAL(rank(psi.A(2)),3);
@@ -132,11 +217,19 @@ SECTION("Orthogonalize")
     auto sites = SpinHalf(10,{"ConserveQNs=",false});
     auto psi = MPS(sites);
 
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(sites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
+
     //Make a random MPS of bond dim. m
     auto links = vector<Index>(N+1);
     for(auto n : range1(N))
         {
-        links.at(n) = Index(m,format("Link,MPS,%d",n));
+        links.at(n) = Index(m,format("Link,l=%d",n));
         }
     psi.Aref(1) = randomITensor(links.at(1),sites(1));
     for(auto n : range1(2,N-1))
@@ -144,6 +237,14 @@ SECTION("Orthogonalize")
         psi.Aref(n) = randomITensor(links.at(n-1),sites(n),links.at(n));
         }
     psi.Aref(N) = randomITensor(links.at(N-1),sites(N));
+
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(sites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
 
     //Normalize psi
     auto n2 = overlap(psi,psi);
@@ -158,6 +259,14 @@ SECTION("Orthogonalize")
 
     psi.orthogonalize({"Cutoff",1E-16});
     CHECK_CLOSE(overlap(opsi,psi),1.0);
+
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(sites(n)==findIndex(psi.A(n),format("n=%d",n)));
+        }
 
     //for(auto b : range1(psi.N()-1))
     //    {
@@ -180,6 +289,14 @@ SECTION("Orthogonalize")
     for(auto b : range1(psi.N()-1))
         {
         CHECK(linkInd(psi,b).m() <= 10);
+        }
+
+    for(int n = 1; n < N; ++n)
+        {
+        auto ln = commonIndex(psi.A(n),psi.A(n+1),"Link");
+        CHECK(ln==findIndex(psi.A(n),format("l=%d",n)));
+        CHECK(ln==findIndex(psi.A(n+1),format("l=%d",n)));
+        CHECK(sites(n)==findIndex(psi.A(n),format("n=%d",n)));
         }
 
     }


### PR DESCRIPTION
I have tried to make the tag conventions a bit more sane for MPS and MPO.

Both now have the conventions that the sites have tags "Site,n=#", and links have conventions "Link,l=#". I added tests to check that some basic MPS and MPO operations like gauging, adding, applyMPO, etc respect the tag convention. 

I think I have missed some spots, and it would be nice to have a good way for users to specify their own convention, but I think this is a good start.