### PR TITLE
Additional IndexSet operations (union, intersection, difference, select, filter, vector)

### DIFF
--- a/itensor/indexset.h
+++ b/itensor/indexset.h
@@ -144,9 +144,9 @@ class IndexSetT : public RangeT<index_type_>
     range() const { return *this; }
 
     // ---------------------------------------------
-    // Indexset arithmetic
-    // Useful for higher-order tensors index manipulation
-
+    // Indexset arithmetic & tools
+    // Useful additions for higher-order tensors index manipulation
+    
     // Boolean union A+B
     // Returns a new IndexSet with all the indices of A and B together
     IndexSetT operator+(IndexSetT &other)
@@ -217,6 +217,30 @@ class IndexSetT : public RangeT<index_type_>
                 }
             }
         return IndexSetT(inds);
+        }
+    
+    // Select from IndexSet by type
+    // This generalizes findtype() to multiple indices
+    IndexSetT select(IndexType type)
+        {
+            std::vector< index_type > inds;
+            for (auto& J : (*this))
+                {
+                    if (J.type() == type) inds.push_back(J);
+                }
+            return IndexSetT(inds);
+        }
+    
+    // Filter IndexSet by type
+    // This generalizes the complement of findtype() to multiple indices
+    IndexSetT filter(IndexType type)
+        {
+            std::vector< index_type > inds;
+            for (auto& J : (*this))
+                {
+                    if (J.type() != type) inds.push_back(J);
+                }
+            return IndexSetT(inds);
         }
     
     // Utility function

--- a/unittest/indexset_test.cc
+++ b/unittest/indexset_test.cc
@@ -80,6 +80,52 @@ SECTION("Constructors")
 
     }
 
+SECTION("IndexSet Arithmetic")
+{
+    SECTION("Union A+B")
+    {
+        IndexSet A(i1,i2,i3,prime(i3),i4);
+        IndexSet B(i3,i4,prime(i4),i5,i6);
+        IndexSet C = A + B;
+        CHECK(hasindex(C,i1));
+        CHECK(hasindex(C,i2));
+        CHECK(hasindex(C,i3));
+        CHECK(hasindex(C,i4));
+        CHECK(hasindex(C,i5));
+        CHECK(hasindex(C,i6));
+        CHECK(hasindex(C,prime(i3)));
+        CHECK(hasindex(C,prime(i4)));
+    }
+    SECTION("Intersection A*B")
+    {
+        IndexSet A(i1,i2,i3,prime(i3),i4);
+        IndexSet B(i3,i4,prime(i4),i5,i6);
+        IndexSet C = A * B;
+        CHECK(!hasindex(C,i1));
+        CHECK(!hasindex(C,i2));
+        CHECK(hasindex(C,i3));
+        CHECK(hasindex(C,i4));
+        CHECK(!hasindex(C,i5));
+        CHECK(!hasindex(C,i6));
+        CHECK(!hasindex(C,prime(i3)));
+        CHECK(!hasindex(C,prime(i4)));
+    }
+    SECTION("Difference A-B")
+    {
+        IndexSet A(i1,i2,i3,prime(i3),i4);
+        IndexSet B(i3,i4,prime(i4),i5,i6);
+        IndexSet C = A - B;
+        CHECK(hasindex(C,i1));
+        CHECK(hasindex(C,i2));
+        CHECK(!hasindex(C,i3));
+        CHECK(!hasindex(C,i4));
+        CHECK(!hasindex(C,i5));
+        CHECK(!hasindex(C,i6));
+        CHECK(hasindex(C,prime(i3)));
+        CHECK(!hasindex(C,prime(i4)));
+    }
+}
+
 SECTION("PrimeLevelMethods")
 {
 SECTION("Prime All")

--- a/unittest/indexset_test.cc
+++ b/unittest/indexset_test.cc
@@ -17,6 +17,7 @@ auto i7 = Index("i7",7);
 auto i8 = Index("i8",8);
 auto i9 = Index("i9",9);
 auto i10 = Index("i10",10);
+auto x1 = Index("x2",2,Xtype);
 auto v1 = Index("v1",2,Vtype);
 auto w1 = Index("w1",2,Wtype);
 
@@ -123,6 +124,22 @@ SECTION("IndexSet Arithmetic")
         CHECK(!hasindex(C,i6));
         CHECK(hasindex(C,prime(i3)));
         CHECK(!hasindex(C,prime(i4)));
+    }
+    SECTION("Select")
+    {
+        IndexSet A(x1,v1,w1);
+        IndexSet B = A.select(Xtype);
+        CHECK(hasindex(B,x1));
+        CHECK(!hasindex(B,v1));
+        CHECK(!hasindex(B,w1));
+    }
+    SECTION("Filter")
+    {
+        IndexSet A(x1,v1,w1);
+        IndexSet B = A.filter(Xtype);
+        CHECK(!hasindex(B,x1));
+        CHECK(hasindex(B,v1));
+        CHECK(hasindex(B,w1));
     }
 }
 


### PR DESCRIPTION
I've been working on some high-rank tensors with many indices of various types, and I find that ITensor was lacking a way to easily manipulate many indices at once. The functions `commonIndex` and `findtype` only return the first match, which is completely insufficient in such cases where multiple indices are required.

These additions to the `IndexSet` class allow us to perform these set-based operations quickly and easily, and immediately use them on any function which accepts `IndexSet` as an input. If they don't (unfortunately, some do not), there's also a `.vector()` method which returns the vector of indices which is typically accepted.

**Example**

Given two `IndexSet`instances `A = {i,j,k,l}` and `B = {k,l,m}`

- `A+B = {i,j,k,l,m}`
- `A*B = {k,l}`
- `A-B = {i,j}`

The `.select()` and `.filter()` methods allow the user to further manipulate such sets by type.

See code comments for more details. Proper unit tests were also included in these commits.