### PR TITLE
Silent DMRG

### DIFF
--- a/itensor/index.h
+++ b/itensor/index.h
@@ -89,6 +89,8 @@ class Index
     // Returns the bond dimension
     long 
     m() const { return m_; }
+    long 
+    dim() const { return m_; }
 
     // Returns the prime level
     int 
@@ -215,6 +217,8 @@ class IndexVal
 
     long
     m() const { return index.m(); }
+    long
+    dim() const { return index.dim(); }
 
     explicit operator bool() const { return bool(index); }
 
@@ -280,6 +284,11 @@ noprime(IndexVal I, VarArgs&&... vargs) { I.noprime(std::forward<VarArgs>(vargs)
 IndexVal inline
 mapprime(IndexVal I, int plevold, int plevnew, IndexType type = All)
     { I.mapprime(plevold,plevnew,type); return I; }
+
+long inline
+dim(Index const& I) { return I.dim(); }
+long inline
+dim(IndexVal const& iv) { return iv.dim(); }
 
 //Make a new index with same properties as I,
 //but a different id number (will not compare equal)

--- a/itensor/indexset.h
+++ b/itensor/indexset.h
@@ -552,6 +552,78 @@ operator+(typename IndexSetIter<T>::difference_type d,
     return x += d;
     } 
 
+
+//
+// IndexValIter - helper for iterInds
+//
+
+namespace detail {
+
+template<typename IndexT>
+struct IndexValIter
+    {
+    using indexval_type = typename IndexT::indexval_type;
+
+    IndexSetT<IndexT> const& is;
+    detail::GCounter count;
+    bool done = false;
+    IndexValIter(IndexSetT<IndexT> const& is_) 
+      : is(is_),
+        count(is_.size())
+        { 
+        for(auto n : range(is.size()))
+            {
+            count.setRange(n,0,is[n].m()-1);
+            }
+        }
+
+    IndexValIter
+    begin() const { return *this; }
+
+    IndexValIter
+    end() const 
+        { 
+        auto eit = *this;
+        eit.done = true;
+        //for(auto n : range(is.size())) 
+        //    {
+        //    eit.count.setRange(n,is[n].m()-1,is[n].m()-1);
+        //    }
+        return eit;
+        }
+
+    bool
+    operator!=(IndexValIter const& other) { return done != other.done; }
+
+    std::vector<indexval_type>
+    operator*() 
+        { 
+        auto res = std::vector<indexval_type>(is.size());
+        for(auto n : range(is.size())) 
+            {
+            res.at(n) = is[n](1+count[n]);
+            }
+        return res;
+        }
+
+    IndexValIter&
+    operator++()
+        {
+        ++count;
+        done = !count.notDone();
+        return *this;
+        }
+    };
+
+} //namespace detail
+
+template<class I>
+detail::IndexValIter<I>
+iterInds(IndexSetT<I> const& is)
+    {
+    return detail::IndexValIter<I>(is);
+    }
+
 } //namespace itensor
 
 #include "itensor/indexset_impl.h"

--- a/itensor/itensor_interface.h
+++ b/itensor/itensor_interface.h
@@ -571,6 +571,13 @@ template<class I>
 ITensorT<I>
 multSiteOps(ITensorT<I> A, ITensorT<I> const& B);
 
+template<class I>
+detail::IndexValIter<I>
+iterInds(ITensorT<I> const& T)
+    {
+    return iterInds(T.inds());
+    }
+
 std::ostream& 
 operator<<(std::ostream & s, ITensor const& T);
 

--- a/itensor/mps/DMRGObserver.h
+++ b/itensor/mps/DMRGObserver.h
@@ -102,48 +102,53 @@ measure(Args const& args)
             //    }
             }
         }
-
-    if(printeigs)
+    
+    if(!args.getBool("Silent",false))
         {
-        if(b == N/2 && ha == 2)
+        if(printeigs)
             {
-            println();
-            auto center_eigs = last_spec_.eigsKept();
-            Real S = 0;
-            for(auto& p : center_eigs)
+            if(b == N/2 && ha == 2)
                 {
-                if(p > 1E-13) S += p*log(p);
+                println();
+                auto center_eigs = last_spec_.eigsKept();
+                Real S = 0;
+                for(auto& p : center_eigs)
+                    {
+                    if(p > 1E-13) S += p*log(p);
+                    }
+                S *= -1;
+                printfln("    vN Entropy at center bond b=%d = %.12f",N/2,S);
+                printf(  "    Eigs at center bond b=%d: ",N/2);
+                auto ten = decltype(center_eigs.size())(10);
+                for(auto j : range(std::min(center_eigs.size(),ten)))
+                    {
+                    auto eig = center_eigs(j);
+                    if(eig < 1E-3) break;
+                    printf("%.4f ",eig);
+                    }
+                println();
                 }
-            S *= -1;
-            printfln("    vN Entropy at center bond b=%d = %.12f",N/2,S);
-            printf(  "    Eigs at center bond b=%d: ",N/2);
-            auto ten = decltype(center_eigs.size())(10);
-            for(auto j : range(std::min(center_eigs.size(),ten)))
-                {
-                auto eig = center_eigs(j);
-                if(eig < 1E-3) break;
-                printf("%.4f ",eig);
-                }
-            println();
             }
         }
 
     max_eigs = std::max(max_eigs,last_spec_.numEigsKept());
     max_te = std::max(max_te,last_spec_.truncerr());
-    if(b == 1 && ha == 2) 
+    if(!args.getBool("Silent",false))
         {
-        if(!printeigs) println();
-        auto swstr = (nsweep>0) ? format("%d/%d",sw,nsweep) 
-                                : format("%d",sw);
-        println("    Largest m during sweep ",swstr," was ",(max_eigs > 1 ? max_eigs : 1));
-        max_eigs = -1;
-        println("    Largest truncation error: ",(max_te > 0 ? max_te : 0.));
-        max_te = -1;
-        printfln("    Energy after sweep %s is %.12f",swstr,energy);
+        if(b == 1 && ha == 2) 
+            {
+            if(!printeigs) println();
+            auto swstr = (nsweep>0) ? format("%d/%d",sw,nsweep) 
+                                    : format("%d",sw);
+            println("    Largest m during sweep ",swstr," was ",(max_eigs > 1 ? max_eigs : 1));
+            max_eigs = -1;
+            println("    Largest truncation error: ",(max_te > 0 ? max_te : 0.));
+            max_te = -1;
+            printfln("    Energy after sweep %s is %.12f",swstr,energy);
+            }
+
         }
-
     }
-
 
 template<class Tensor>
 bool inline DMRGObserver<Tensor>::

--- a/itensor/mps/autompo.cc
+++ b/itensor/mps/autompo.cc
@@ -1433,8 +1433,8 @@ template<>
 IQMPO 
 toMPO(AutoMPO const& am, 
       Args const& args) 
-    { 
-    auto verbose = args.getBool("Verbose",false);
+    {
+    auto verbose = args.getBool("Verbose", false);
     if(args.getBool("Exact",false))
         {
         if(verbose) println("Using exact conversion of AutoMPO->IQMPO");
@@ -1448,13 +1448,14 @@ template<>
 MPO 
 toMPO(AutoMPO const& am, 
       Args const& args) 
-    { 
+    {
+    auto verbose = args.getBool("Verbose", false);
     if(args.getBool("Exact",false))
         {
-        println("Using exact conversion of AutoMPO->MPO");
+        if(verbose) println("Using exact conversion of AutoMPO->MPO");
         return toMPOImpl<ITensor>(am,{args,"CheckQN",false});
         }
-    println("Using approx/svd conversion of AutoMPO->MPO");
+    if(verbose) println("Using approx/svd conversion of AutoMPO->MPO");
     return svdMPO<ITensor>(am,{args,"CheckQN",false});
     }
 

--- a/itensor/mps/dmrg.h
+++ b/itensor/mps/dmrg.h
@@ -193,7 +193,9 @@ DMRGWorker(MPSt<Tensor>& psi,
            DMRGObserver<Tensor>& obs,
            Args args = Global::args())
     {
-    const bool quiet = args.getBool("Quiet",false);
+    const bool silent = args.getBool("Silent",false);
+    const bool quiet = silent || args.getBool("Quiet",false); // silent overrules quiet
+    
     const int debug_level = args.getInt("DebugLevel",(quiet ? 0 : 1));
     const bool ignore_degeneracy = args.getBool("IgnoreDegeneracy",false);
 
@@ -270,9 +272,11 @@ DMRGWorker(MPSt<Tensor>& psi,
             } //for loop over b
 
         auto sm = sw_time.sincemark();
+        if (!silent)
+            {
         printfln("    Sweep %d/%d CPU time = %s (Wall time = %s)",
                   sw,sweeps.nsweep(),showtime(sm.time),showtime(sm.wall));
-
+            }
         if(obs.checkDone(args)) break;
     
         } //for loop over sw


### PR DESCRIPTION
- Fixed a small bug, in which the "verbose" option on DMRG worked for IQMPOs but not for MPOs.
- Added an extra setting, "Silent", which implies Quiet and also suppresses all other outputs. (This is desirable if DMRG is used as a sub-routine on an algorithm.)