### PR TITLE
Minimize Clang Warning

### DIFF
--- a/itensor/itensor_interface_impl.h
+++ b/itensor/itensor_interface_impl.h
@@ -734,7 +734,7 @@ ITensorT<I>
 operator*(ITensorT<I> A, ITensorT<I> const& B) { A *= B; return A; }
 template<typename I>
 ITensorT<I>
-operator*(ITensorT<I> const& A, ITensorT<I>&& B) { B *= A; return B; }
+operator*(ITensorT<I> const& A, ITensorT<I>&& B) { B *= A; return std::move(B); }
 template<typename I>
 ITensorT<I> 
 operator*(ITensorT<I> T, Real fac) { T *= fac; return T; }
@@ -759,21 +759,21 @@ ITensorT<I>
 operator+(ITensorT<I> A, const ITensorT<I>& B) { A += B; return A; }
 template<typename I>
 ITensorT<I> 
-operator+(ITensorT<I> const& A, ITensorT<I>&& B) { B += A; return B; }
+operator+(ITensorT<I> const& A, ITensorT<I>&& B) { B += A; return std::move(B); }
 
 template<typename I>
 ITensorT<I> 
 operator-(ITensorT<I> A, const ITensorT<I>& B) { A -= B; return A; }
 template<typename I>
 ITensorT<I> 
-operator-(ITensorT<I> const& A, ITensorT<I>&& B) { B -= A; B *= -1; return B; }
+operator-(ITensorT<I> const& A, ITensorT<I>&& B) { B -= A; B *= -1; return std::move(B); }
 
 template<typename I>
 ITensorT<I> 
 operator/(ITensorT<I> A, ITensorT<I> const& B) { A /= B; return A; }
 template<typename I>
 ITensorT<I>
-operator/(ITensorT<I> const& A, ITensorT<I> && B) { B /= A; return B; }
+operator/(ITensorT<I> const& A, ITensorT<I> && B) { B /= A; return std::move(B); }
 
 
 template<typename IndexT, typename... VarArgs>


### PR DESCRIPTION
Clang 8 throws following warning -->
warning: local variable 'B' will be copied despite being returned by name [-Wreturn-std-move]
....
 note: call 'std::move' explicitly to avoid copying