### PR TITLE
Add AutoMPO concat function for local operators

### DIFF
--- a/itensor/mps/autompo.h
+++ b/itensor/mps/autompo.h
@@ -190,10 +190,11 @@ class AutoMPO
 
     public:
 
-    AutoMPO() { }
+    AutoMPO(): concatAccumulator(nullptr) 
+        { }
 
     AutoMPO(SiteSet const& sites) 
-      : sites_(sites)
+      : sites_(sites), concatAccumulator(nullptr)
         { }
 
     SiteSet const&
@@ -213,11 +214,52 @@ class AutoMPO
     Accumulator
     operator+=(T x) { return Accumulator(this,x); }
 
+    template <typename T>
+    AutoMPO&
+    concat(T x)
+      {
+      if (concatAccumulator==nullptr)
+        {
+        concatAccumulator = new Accumulator(this,x); 
+        }
+      else { (*concatAccumulator),x; }
+      
+      return *this;
+      }
+
+    template <typename T, typename... VarArgs>
+    AutoMPO&
+    concat(T first, VarArgs... vargs) 
+      { 
+      if (concatAccumulator==nullptr) 
+        { 
+        concatAccumulator = new Accumulator(this,first); 
+        return concat(vargs...);
+        }
+      else 
+        {
+        (*concatAccumulator),first;
+        return concat(vargs...);
+        }
+      }
+    
+    //this calls add with the completed accumulator
+    void combine() 
+      { 
+      delete concatAccumulator; 
+      concatAccumulator=nullptr; 
+      } 
+
     void
     add(HTerm const& t);
 
     void
     reset() { terms_.clear(); }
+
+    private:
+
+    //temporary accumulator for concat
+    Accumulator* concatAccumulator;
     };
 
 std::ostream& 


### PR DESCRIPTION
Addressing #219 and [this forum post](http://itensor.org/support/1212/autompo-syntax-concatenate-local-terms?show=1212), this provides a concatenation function for local operators and `AutoMPO`

Usage:
```c++
auto ampo = AutoMPO(sites);

//loop in a function
for(auto n: range1(N))
   ampo.concat("Sz",n);
ampo.combine(); //done concating, does the += step

//For coefficients and a function
Real J = -1.7;
//same as ampo += J,"Sz",1,"Sz",2,"Sz",3;
ampo.concat(J);
for(auto n: range1(3))
    ampo.concat("Sz",n);
ampo.combine();

//don't like the comma operator? This works too
//same as ampo += 3.14,"Nup",2,"Ndn",4,"Nupdn",7";
ampo.concat(3.14,"Nup",2)
    .concat("Ndn",4,"Nupdn",7) //takes any number of arguments
    .combine();
``` 
Caveat: only one concat sequence is allowed at a time. 

I'm not 100% in love with the names, so please feel free to suggest alternatives.  