### PR TITLE
Changed project_template's Makefile's LIBRARY_DIR

### DIFF
--- a/tutorial/project_template/Makefile
+++ b/tutorial/project_template/Makefile
@@ -3,7 +3,7 @@
 
 # 2. Edit LIBRARY_DIR to point at the location of your ITensor Library
 #    source folder (this is the folder that has options.mk in it)
-LIBRARY_DIR=$(HOME)/software/itensor
+LIBRARY_DIR=$(HOME)/itensor
 
 # 3. If your 'main' function is in a file called 'myappname.cc', then
 #    set APP to 'myappname'. Running 'make' will compile the app.


### PR DESCRIPTION
Changed project_template's Makefile's LIBRARY_DIR to (HOME)/itensor instead of (HOME)/software/itensor so it is consistent with installation instructions on the website, where one would normally clone ITensor to the (HOME) folder directly (on a Unix system), rather than have an intermediate /software/ folder. Without this change the Makefile in the project_template does not work out of the box (errors that folder does not exist), and might confuse some people.