### PR TITLE
added possibility of defining Emp to the bosonic siteset

### DIFF
--- a/itensor/mps/sites/boson.h
+++ b/itensor/mps/sites/boson.h
@@ -79,6 +79,7 @@ class BosonSite
             {
             if(state == str(n)) return s(1+n);
             }
+	if(state == "Emp")return s(1);
         Error("State " + state + " not recognized");
         return IndexVal{};
         }


### PR DESCRIPTION
This allows for a mixed site set like the Holstein MixedSiteSet<Fermion, Boson> to initialize a complete state as unoccupied with setAll("Emp")