### PR TITLE
Fix eigen

### DIFF
--- a/unittest/decomp_test.cc
+++ b/unittest/decomp_test.cc
@@ -727,4 +727,37 @@ SECTION("Exp Hermitian")
         }
     }
 
+SECTION("Eigen")
+    {
+    auto i = Index(2,"i"),
+         j = Index(2,"j"),
+         k = Index(2,"k");
+    auto I = IndexSet(i,j,k);
+    auto Ip = prime(I);
+
+    SECTION("Case 1")
+      {
+      auto A = randomITensor({Ip,I});
+
+      auto [P,D] = eigen(A,{"Tags=","test"});
+
+      auto d = commonIndex(P,D);
+
+      CHECK(hasTags(d,"test"));
+      CHECK_CLOSE(norm(A*P - prime(P)*D),0.);
+      }
+
+    SECTION("Case 2")
+      {
+      auto A = randomITensor({I,Ip});
+
+      auto [P,D] = eigen(A,{"Tags=","test"});
+
+      auto d = commonIndex(P,D);
+
+      CHECK(hasTags(d,"test"));
+      CHECK_CLOSE(norm(A*P - prime(P)*D),0.);
+      }
+
+    }
 }


### PR DESCRIPTION
Eigen had the following bug:

```C++
  auto i = Index(2,"i"),
       j = Index(2,"j"),
       k = Index(2,"k");
  auto I = IndexSet(i,j,k);
  auto Ip = prime(I);

  auto A = randomITensor({I,Ip});

  auto [V,E] = eigen(A,{"Tags=","test"});

  PrintData(norm(A*V - prime(V)*E));  // Prints non-zero, should be zero
```

If we replace `auto A = randomITensor({Ip,I})`, the `eigen` function works. The problem seems pretty subtle, in that the function forms a MatrixRef out of the data of the ITensor for indices of the form `i',j',k',...,i,j,k,...`. If it gets an ITensor with the indices above, it makes a transposed MatrixRef, and then calls the internal `eigen` for matrices, which uses a special version if the MatrixRef is transposed. It seems like the output of `eigen(MatrixRef,...)` is not being used correctly in that case (it seems to end up with something related to the left eigenvectors, while `eigen(ITensor,...)` is meant to output the right eigenvectors).

The fix I used was just to use `permute(A,{prime(c),c})` where `c` is the combined index of `{i,j,k,...}` so the MatrixRef never needs to be transposed. This may lead to some extra unnecessary copying of data, but I think the time that takes is much less then the time to call `eigen` anyway. There should be a deeper way to fix the bug, but I tried to debug it for a while and couldn't figure out how to get whatever was being output by `eigen` in the transposed case into the correct set of eigenvectors.