### PR TITLE
Fix a bug in davidson where a range was used wrong

### DIFF
--- a/itensor/iterativesolvers.h
+++ b/itensor/iterativesolvers.h
@@ -191,7 +191,7 @@ davidson(BigMatrixT const& A,
             lambda = D(t);
             phi_t = U(0,t)*V[0];
             q     = U(0,t)*AV[0];
-            for(auto k : range(ii+1))
+            for(auto k : range1(ii))
                 {
                 phi_t += U(k,t)*V[k];
                 q     += U(k,t)*AV[k];
@@ -390,15 +390,6 @@ davidson(BigMatrixT const& A,
     //    {
     //    if(T.scale().logNum() > 2) T.scaleTo(1.);
     //    }
-
-    //TODO: previously, it seems like the
-    //eigenvectors were being normalized
-    //automatically, and this was expected
-    //by DMRG (when calculating the proper
-    //entanglement entropy). At some point, 
-    //normalization had to be done explicitly, why?
-    for(auto& phi_j : phi)
-        phi_j /= norm(phi_j);
 
     //Compute any remaining eigenvalues and eigenvectors requested
     //(zero indexed) value of t indicates how many have been "targeted" so far

--- a/unittest/iterativesolvers_test.cc
+++ b/unittest/iterativesolvers_test.cc
@@ -177,7 +177,7 @@ SECTION("Davidson (Custom Linear Map)")
     {
     auto a1 = Index(3,"Site,a1");
     auto a2 = Index(4,"Site,a2");
-    auto a3 = Index(3,"Site,a3");
+    auto a3 = Index(5,"Site,a3");
 
     auto A = randomITensor(prime(a1),prime(a2),prime(a3),a1,a2,a3);
     A = 0.5*(A + swapPrime(dag(A),0,1));
@@ -185,11 +185,8 @@ SECTION("Davidson (Custom Linear Map)")
 
     // ITensorMap is defined above, it simply wraps an ITensor that is of the
     // form of a matrix (i.e. has indices of the form {i,j,k,...,i',j',k',...})
-    auto lambda = davidson(ITensorMap(A),x,{"MaxIter",50,"ErrGoal",1e-10});
+    auto lambda = davidson(ITensorMap(A),x,{"MaxIter",40,"ErrGoal",1e-14});
 
-    // Run it again as a "restart"
-    lambda = davidson(ITensorMap(A),x,{"MaxIter",50,"ErrGoal",1e-10});
- 
     CHECK_CLOSE(norm(noPrime(A*x)-lambda*x)/norm(x),0.0);
 
     }


### PR DESCRIPTION
There was a bug introduced in davidson at some point where a range was rewritten incorrectly, leading to an inaccurate vector being output from davidson. Thanks @PBluntz for noticing this!