### PR TITLE
Add partial direct sum of ITensors

### DIFF
--- a/itensor/index.cc
+++ b/itensor/index.cc
@@ -489,6 +489,38 @@ class IQIndexDat
 #endif
 
 Index
+directSum(Index const& i,
+          Index const& j,
+          Args const& args)
+  {
+  auto tags = getTagSet(args,"Tags","sum");
+  if(not hasQNs(i) && not hasQNs(j))
+    {
+    auto dim_ij = dim(i) + dim(j);
+    if(dim_ij <= 0) dim_ij = 1;
+    return Index(dim_ij,tags);
+    }
+  else
+    {
+#ifdef DEBUG
+    if( dir(i) != dir(j) ) Error("In directSum(Index, Index), input indices must have same arrow direction");
+#endif
+    auto nblock_i = nblock(i);
+    auto nblock_j = nblock(j);
+    auto siq = stdx::reserve_vector<QNInt>(nblock_i+nblock_j);
+    for(auto iqn : range1(nblock_i))
+        siq.emplace_back(qn(i,iqn),blocksize(i,iqn));
+    for(auto jqn : range1(nblock_j))
+        siq.emplace_back(qn(j,jqn),blocksize(j,jqn));
+#ifdef DEBUG
+    if(siq.empty()) Error("siq is empty in plussers");
+#endif
+    return Index(std::move(siq),dir(i),tags);
+    }
+  return Index();
+  }
+
+Index
 sim(Index const& I)
     {
     Index J;

--- a/itensor/index.h
+++ b/itensor/index.h
@@ -476,6 +476,12 @@ setPrime(IndexVal I, int plev);
 IndexVal
 noPrime(IndexVal I); 
 
+// Get the direct sum of two indices
+Index
+directSum(Index const& i,
+          Index const& j,
+          Args const& args = Args::global());
+
 //Make a new index with same properties as I,
 //but a different id number (will not compare equal)
 Index

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -1000,6 +1000,94 @@ operator/(ITensor A, ITensor const& B) { A /= B; return A; }
 ITensor
 operator/(ITensor const& A, ITensor && B) { B /= A; return std::move(B); }
 
+// Create some sparse tensors to help with
+// a partial direct sum
+Index
+directSumITensors(Index const& i,
+                  Index const& j,
+                  ITensor& D1,
+                  ITensor& D2,
+                  Args const& args = Args::global())
+  {
+  auto ij = directSum(i,j,args);
+  if(not hasQNs(i) && not hasQNs(j))
+    {
+    D1 = delta(i,ij);
+    auto S = Matrix(dim(j),dim(ij));
+    for(auto jj : range(dim(j)))
+      {
+      S(jj,dim(i)+jj) = 1;
+      }
+    D2 = matrixITensor(std::move(S),j,ij);
+    }
+  else
+    {
+    D1 = ITensor(dag(i),ij);
+    int n = 1;
+    auto nblock_i = nblock(i);
+    for(auto iq1 : range1(nblock_i))
+        {
+        auto blocksize_i = blocksize(i,iq1);
+        auto blocksize_ij = blocksize(ij,n);
+        auto D = Matrix(blocksize_i,blocksize_ij);
+        auto minsize = std::min(blocksize_i,blocksize_ij);
+        for(auto ii : range(minsize)) D(ii,ii) = 1.0;
+        getBlock<Real>(D1,{iq1,n}) &= D;
+        ++n;
+        }
+    auto nblock_j = nblock(j);
+    D2 = ITensor(dag(j),ij);
+    for(auto iq2 : range1(nblock_j))
+        {
+        auto blocksize_j = blocksize(j,iq2);
+        auto blocksize_ij = blocksize(ij,n);
+        auto D = Matrix(blocksize_j,blocksize_ij);
+        auto minsize = std::min(blocksize_j,blocksize_ij);
+        for(auto ii : range(minsize)) D(ii,ii) = 1.0;
+        getBlock<Real>(D2,{iq2,n}) &= D;
+        ++n;
+        }
+    }
+  return ij;
+  }
+
+std::tuple<ITensor,IndexSet>
+directSum(ITensor const& A, ITensor const& B,
+          IndexSet const& I, IndexSet const& J,
+          Args const& args)
+  {
+  if( order(I) != order(J) ) Error("In directSum(ITensor, ITensor, ...), must sum equal number of indices");
+  auto AD = A;
+  auto BD = B;
+  auto newinds = IndexSetBuilder(I.size());
+  for( auto n : range1(order(I)) )
+    {
+    auto In = I(n);
+    auto Jn = J(n);
+    if( dir(A,In) != dir(In) ) In.dag();
+    if( dir(B,Jn) != dir(Jn) ) Jn.dag();
+    ITensor D1, D2;
+    auto IJn = directSumITensors(In,Jn,D1,D2,args);
+    newinds.nextIndex(IJn);
+    AD *= D1;
+    BD *= D2;
+    }
+  auto IJ = newinds.build();
+  auto C = AD+BD;
+  return std::make_tuple(C,IJ);
+  }
+
+// Direct sum A and B over indices i on A and j on B
+std::tuple<ITensor,Index>
+directSum(ITensor const& A, ITensor const& B,
+          Index const& i, Index const& j,
+          Args const& args)
+  {
+  auto [C,IJ] = directSum(A,B,IndexSet(i),IndexSet(j),args);
+  auto ij = IJ.index(1);
+  return std::make_tuple(C,ij);
+  }
+
 void
 daxpy(ITensor & L,
       ITensor const& R,
@@ -1090,6 +1178,13 @@ hasIndex(ITensor const& T,
          Index const& imatch)
     {
     return hasIndex(inds(T),imatch);
+    }
+
+Arrow
+dir(ITensor const& T,
+    Index const& i)
+    {
+    return dir(inds(T),i);
     }
 
 bool

--- a/itensor/itensor.h
+++ b/itensor/itensor.h
@@ -530,6 +530,18 @@ operator/(ITensor A, ITensor const& B);
 ITensor
 operator/(ITensor const& A, ITensor && B);
 
+// Partial direct sum of ITensors A and B
+// over the specified indices
+std::tuple<ITensor,IndexSet>
+directSum(ITensor const& A, ITensor const& B,
+          IndexSet const& I, IndexSet const& J,
+          Args const& args = Args::global());
+
+std::tuple<ITensor,Index>
+directSum(ITensor const& A, ITensor const& B,
+          Index const& i, Index const& j,
+          Args const& args = Args::global());
+
 //
 // ITensor tag functions
 //
@@ -706,6 +718,10 @@ hasIndex(ITensor const& T,
 bool
 hasInds(ITensor const& T,
         IndexSet const& ismatch);
+
+Arrow
+dir(ITensor const& T,
+    Index const& i);
 
 template<typename... Inds>
 bool

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -2530,6 +2530,56 @@ SECTION("ITensor Negation")
         }
     }
 
+SECTION("ITensor partial direct sum")
+  {
+  SECTION("No QNs")
+    {
+    auto a = Index(2,"a"),
+         b = Index(2,"b"),
+         i = Index(2,"i"),
+         j = Index(2,"j");
+
+    auto A = randomITensor(a,b,i);
+    auto B = randomITensor(a,b,j);
+
+    // Version accepting an index on A and an index on B to be direct summed
+    // Here we create a new ITensor C with indices {a,b,i+j}
+    // Indices that are not specified must be shared by A and B
+    auto [C,ij] = directSum(A,B,i,j,{"Tags=","i+j"});
+
+    CHECK_CLOSE(C.elt(a=1,b=1,ij=1),A.elt(a=1,b=1,i=1));
+    CHECK_CLOSE(C.elt(a=1,b=1,ij=dim(i)+1),B.elt(a=1,b=1,j=1));
+    }
+  SECTION("QNs")
+    {
+    auto a = Index(QN(-1),2,
+                   QN(0),2,
+                   QN(+1),2,"a");
+
+    auto b = Index(QN(-1),2,
+                   QN(0),2,
+                   QN(+1),2,"b");
+
+    auto i = Index(QN(-1),2,
+                   QN(0),2,
+                   QN(+1),2,"i");
+
+    auto j = Index(QN(-1),2,
+                   QN(0),2,
+                   QN(+1),2,"j");
+
+    auto A = randomITensor(QN(0),a,b,dag(i));
+    auto B = randomITensor(QN(0),a,b,dag(j));
+
+    // Version accepting an index on A and an index on B to be direct summed
+    // Here we create a new ITensor C with indices {a,b,i+j}
+    // Indices that are not specified must be shared by A and B
+    auto [C,ij] = directSum(A,B,i,j,{"Tags=","i+j"});
+
+    CHECK_CLOSE(C.elt(a=1,b=1,ij=1),A.elt(a=1,b=1,i=1));
+    CHECK_CLOSE(C.elt(a=1,b=1,ij=dim(i)+1),B.elt(a=1,b=1,j=1));
+    }
+  }
 
 } //TEST_CASE("ITensor")
 


### PR DESCRIPTION
This implements functions for performing direct sums of indices and ITensors.

The `directSum(ITensor,ITensor,...)` implements the "partial direct sum" as defined in:

https://arxiv.org/abs/1405.7786

This allows a user to perform a direct sum of ITensors over specified indices of those ITensors.