### PR TITLE
Add toDense(ITensor) function

### DIFF
--- a/itensor/itdata/diag.cc
+++ b/itensor/itdata/diag.cc
@@ -418,4 +418,29 @@ doTask(SumEls S, Diag<T> const& d)
 template Cplx doTask(SumEls S, DiagReal const& d);
 template Cplx doTask(SumEls S, DiagCplx const& d);
 
+template<typename V>
+void
+doTask(ToDense & R,
+       Diag<V> const& d,
+       ManageStore & m)
+    {
+    auto nd = m.makeNewData<Dense<V>>(dim(R.is),0.);
+    auto Nref = makeTenRef(nd->data(),nd->size(),&R.is);
+    long tot_stride = 0; //total strides
+    for(auto i : range(length(R.is)))
+      tot_stride += R.is.stride(i);
+    if(d.allSame())
+      {
+      for(auto i : range(d.length))
+        Nref[i*tot_stride] = d.val;
+      }
+    else
+      {
+      for(auto i : range(d.length))
+        Nref[i*tot_stride] = d.store[i];
+      }
+    }
+template void doTask(ToDense &, Diag<Real> const&, ManageStore &);
+template void doTask(ToDense &, Diag<Cplx> const&, ManageStore &);
+
 } //namespace itensor

--- a/itensor/itdata/diag.h
+++ b/itensor/itdata/diag.h
@@ -269,6 +269,10 @@ doTask(StorageType const& S, DiagReal const& d) ->StorageType::Type { return Sto
 auto inline
 doTask(StorageType const& S, DiagCplx const& d) ->StorageType::Type { return StorageType::DiagCplx; }
 
+template<typename T>
+void
+doTask(ToDense &, Diag<T> const&, ManageStore &);
+
 } //namespace itensor
 
 #endif

--- a/itensor/itdata/qdiag.h
+++ b/itensor/itdata/qdiag.h
@@ -365,6 +365,10 @@ template<typename V>
 void
 doTask(RemoveQNs &, QDiag<V> const&, ManageStore &);
 
+template<typename T>
+void
+doTask(ToDense &, QDiag<T> const&, ManageStore &);
+
 } //namespace itensor
 
 #endif

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -558,6 +558,15 @@ struct RemoveQNs
 inline const char*
 typeNameOf(RemoveQNs) { return "RemoveQNs";}
 
+struct ToDense
+    {
+    IndexSet const& is;
+    ToDense(IndexSet const& is_) : is(is_) {}
+    };
+
+inline const char*
+typeNameOf(ToDense) { return "ToDense";}
+
 } //namespace itensor 
 
 #endif

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -868,19 +868,15 @@ operator*=(ITensor const& R)
 
 #ifndef USESCALE
 
-////for Diag and QDiag
-////QDense -> Dense
-////QDiag  -> Dense
-////Diag   -> Dense
-//ITensor
-//toDense(ITensor T)
-//    {
-//    if(not hasQNs(T)) return T;
-//    if(T.store()) doTask(ToDense{T.inds()},T.store());
-//    auto nis = T.inds();
-//    nis.removeQNs();
-//    return ITensor{move(nis),move(T.store()),T.scale()};
-//    }
+//for Diag and QDiag
+//Diag  -> Dense
+//QDiag -> QDense
+ITensor
+toDense(ITensor T)
+    {
+    if(T.store()) doTask(ToDense{T.inds()},T.store());
+    return ITensor{move(T.inds()),move(T.store()),T.scale()};
+    }
 
 //TODO: make this use a RemoveQNs task type that does:
 //QDense -> Dense

--- a/itensor/itensor.h
+++ b/itensor/itensor.h
@@ -1005,6 +1005,9 @@ bool
 hasQNs(ITensor const& T);
 
 ITensor
+toDense(ITensor T);
+
+ITensor
 removeQNs(ITensor T);
 
 template<typename V>

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -488,21 +488,29 @@ ITensor
 diagITensor(Container const& C, 
             IndexSet const& is)
     { 
+    if( not hasQNs(is) )
+      {
 #ifdef DEBUG
-    using size_type = decltype(C.size());
-    //Compute min of all index dimensions
-    auto mindim = dim(is[0]);
-    for(const auto& ind : is)
-        if(dim(ind) < mindim) mindim = dim(ind);
-    if(C.size() != size_type(mindim))
-        {
-        println("mindim = ",mindim);
-        println("C.size() = ",C.size());
-        Error("Wrong size of data in diagonal ITensor constructor");
-        }
+      using size_type = decltype(C.size());
+      //Compute min of all index dimensions
+      auto mindim = dim(is[0]);
+      for(const auto& ind : is)
+          if(dim(ind) < mindim) mindim = dim(ind);
+      if(C.size() != size_type(mindim))
+          {
+          println("mindim = ",mindim);
+          println("C.size() = ",C.size());
+          Error("Wrong size of data in diagonal ITensor constructor");
+          }
 #endif
-    using value_type = typename Container::value_type;
-    return ITensor(std::move(is),Diag<value_type>(C.begin(),C.end()));
+      using value_type = typename Container::value_type;
+      return ITensor(std::move(is),Diag<value_type>(C.begin(),C.end()));
+      }
+    else
+      {
+      Error("diagITensor constructor not yet implemented for QNs");
+      return ITensor();
+      }
     }
 
 template<typename V>


### PR DESCRIPTION
This adds a `toDense(ITensor)` function that converts an ITensor with Diag storage to an equivalent ITensor with Dense storage (and the same for QDiag -> QDense).

This is useful to help users who come across functionality that is not defined for Diag and QDiag storage types but are defined for Dense and QDense storage types (in non-performance critical parts of code).