### PR TITLE
Backport patch to eigen from v3 (wasn't working with certain inputs)

### DIFF
--- a/itensor/decomp.cc
+++ b/itensor/decomp.cc
@@ -535,6 +535,18 @@ eigen(ITensorT<index_type> const& T,
 
     auto Tc = prime(comb) * T * comb; 
 
+    // The version where Tc is ordered
+    // {cind,prime(cind)} does not work,
+    // here we will explicitly permute the
+    // ITensor so the indices are ordered
+    // {prime(cind),cind}.
+    // This is not great since it is an
+    // extra reordering of the data,
+    // look into fixing eigen properly.
+    auto cind = commonIndex(Tc,comb);
+    if(Tc.index(1) != prime(cind))
+      Tc.order(prime(cind),cind);
+
     ITensorT<index_type> L;
     if(isComplex(T))
         {


### PR DESCRIPTION
`eigen` wasn't working with certain types of input ITensors:

```C++
auto i = Index("i",2),
     j = Index("j",2),
     k = Index("k",2);
auto A = randomTensor(i,j,k,prime(i),prime(j),prime(k));
ITensor V,D;
eigen(A,V,D);
PrintData(norm(A*V - prime(V)*D));
```

This backports a simple fix that I used in v3 to fix the same problem.