### PR TITLE
Add an ITensor constructor accepting the desired flux

### DIFF
--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -71,6 +71,13 @@ ITensor(Cplx val)
         }
     }
 
+ITensor::
+ITensor(QN q, IndexSet const& is)
+  :
+  is_(std::move(is))
+  {
+  store_ = newITData<QDenseReal>(is,q); 
+  }
 
 Cplx ITensor::
 eltC() const

--- a/itensor/itensor.h
+++ b/itensor/itensor.h
@@ -63,6 +63,13 @@ class ITensor
     //explicit
     //ITensor(std::array<Index,N> const& inds);
 
+    ITensor(QN q, IndexSet const& inds);
+
+    template <typename... Inds>
+    explicit
+    ITensor(QN q, Index const& i1,
+            Inds const&... inds);
+
     //Construct order 0 tensor (scalar), value set to val
     //If val.imag()==0, storage will be Real
     explicit

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -48,6 +48,14 @@ ITensor(Index  const& i1,
     IF_USESCALE(scale_ = LogNum(1.);)
     }
 
+template <typename... Inds>
+ITensor::
+ITensor(QN q, Index  const& i1,
+        Inds const&... inds)
+    {
+    *this = ITensor(q,IndexSet(i1,inds...));
+    }
+
 template <class DataType>
 ITensor::
 ITensor(IndexSet iset,

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -298,6 +298,12 @@ SECTION("Diag Rank 2 from container")
     CHECK_DIFF(norm(T),std::sqrt(nrm),1E-10);
     CHECK_DIFF(sumels(T),tot,1E-10);
     }
+
+SECTION("QDense")
+  {
+  auto T = ITensor(QN(+1),S1,dag(S2),S3);
+  CHECK_CLOSE(norm(T),0.);
+  }
 }
 
 SECTION("Write to Disk")


### PR DESCRIPTION
@emstoudenmire, does this seem like a reasonable thing to add? It mirrors the `randomITensor` constructor.

@PBluntz needed to make an ITensor filled with zeros with a particular divergence and I realized that it is harder than it should be to do that. The most straightforward way we could think of was `0.*randomITensor(QN(2),i,j,k)` (which is not very nice). Otherwise you have to make a default ITensor with the indices and then set an element to zero, but you would need to know a location in the tensor that has the flux you want which is a bit annoying. Perhaps there is an easier way we are not seeing, but this constructor seems like the most straightforward way.