### PR TITLE
Add some more Matrix operations, extend expMatrix to Real inputs

### DIFF
--- a/itensor/tensor/algs.h
+++ b/itensor/tensor/algs.h
@@ -120,18 +120,20 @@ SVD(MatM && M,
 // Hermitian Matrix exponentiate
 // by diagHermitian
 //
-template<class MatM, class MatF,
-         class = stdx::require<
-         hasMatRange<MatM>,
-         hasMatRange<MatF>
-         >>
-void
+template<class MatM,
+         class ScalarT,
+         class = stdx::require<hasMatRange<MatM>>>
+Mat<common_type<val_type<MatM>,ScalarT>>
 expHermitian(MatM && M,
-             MatF && F,
-             Cplx t);
+                   ScalarT t);
+
+template<class MatM,
+         class = stdx::require<hasMatRange<MatM>>>
+Mat<val_type<MatM>>
+expHermitian(MatM && M) { return expHermitian(M,1.); }
 
 //
-// expGeneral computes exp(tH),
+// expMatrix computes exp(tH),
 // where H is a general dense matrix,
 // and t can be real or complex.
 // Either of the two options can be used:
@@ -142,16 +144,18 @@ expHermitian(MatM && M,
 // using which 14-digit accuracy is expected if tH is negative definite,
 // but may behave poorly otherwise.
 //
-template<class MatH,class MatF,
-         class = stdx::require<
-         hasMatRange<MatH>,
-         hasMatRange<MatF>
-         >>
-void
-expGeneral(MatH && H,
-           MatF && F,
-           Cplx t,
-           int ideg);
+template<class MatM,
+         class ScalarT,
+         class = stdx::require<hasMatRange<MatM>>>
+Mat<common_type<val_type<MatM>,ScalarT>>
+expMatrix(MatM && M,
+          ScalarT t,
+          int ideg = 6);
+
+template<class MatM,
+         class = stdx::require<hasMatRange<MatM>>>
+Mat<val_type<MatM>>
+expMatrix(MatM && M) { return expMatrix(M,1.); }
 
 } //namespace itensor
 

--- a/itensor/tensor/mat.cc
+++ b/itensor/tensor/mat.cc
@@ -89,6 +89,12 @@ multReal(MatRef<V> const& M, Real fac)
         }
     }
 
+void
+multCplx(CMatrixRef const& M, Cplx fac)
+    {
+    for(auto& el : M) el *= fac;
+    } 
+
 void 
 operator*=(MatrixRef const& M, Real fac)
     {
@@ -98,6 +104,12 @@ void
 operator*=(CMatrixRef const& M, Real fac)
     {
     multReal(M,fac);
+    }
+
+void
+operator*=(CMatrixRef const& M, Cplx fac)
+    {
+    multCplx(M,fac);
     }
 
 template<typename V>

--- a/itensor/tensor/mat.h
+++ b/itensor/tensor/mat.h
@@ -72,6 +72,9 @@ void
 operator*=(CMatrixRef const& M, Real fac);
 
 void
+operator*=(CMatrixRef const& M, Cplx fac);
+
+void
 operator/=(MatrixRef const& M, Real fac);
 void
 operator/=(CMatrixRef const& M, Real fac);
@@ -206,16 +209,32 @@ Mat<V>
 operator*(MatRefc<V> const& A, Real fac);
 
 template<typename V>
+Mat<V>
+operator*(MatRefc<V> const& A, Cplx fac);
+
+template<typename V>
 Mat<V> 
 operator*(Real fac, MatRefc<V> const& A);
+
+template<typename V>
+Mat<V>
+operator*(Cplx fac, MatRefc<V> const& A);
 
 template<typename V>
 Mat<V> 
 operator*(Mat<V> && A, Real fac);
 
 template<typename V>
+Mat<V>
+operator*(Mat<V> && A, Cplx fac);
+
+template<typename V>
 Mat<V> 
 operator*(Real fac, Mat<V> && A);
+
+template<typename V>
+Mat<V>
+operator*(Cplx fac, Mat<V> && A);
 
 template<typename V>
 Mat<V> 

--- a/itensor/tensor/mat_impl.h
+++ b/itensor/tensor/mat_impl.h
@@ -47,6 +47,21 @@ operator*(MatA const& A, Real fac)
 
 template<typename MatA,
          class = stdx::require<hasMatRange<MatA>> >
+Mat<val_type<MatA>>
+operator*(MatA const& A, Cplx fac)
+    {
+    Mat<val_type<MatA>> res(A);
+    res *= fac;
+    return res;
+    }
+
+template<typename MatA,
+         class = stdx::require<hasMatRange<MatA>> >
+Mat<val_type<MatA>>
+operator*(Cplx fac, MatA const& A) { return A*fac; }
+
+template<typename MatA,
+         class = stdx::require<hasMatRange<MatA>> >
 Mat<val_type<MatA>> 
 operator*(Real fac, MatA const& A)
     { 
@@ -65,6 +80,28 @@ operator*(Mat<V> && A, Real fac)
     }
 
 template<typename V>
+Mat<V>
+operator*(Mat<V> && A, Cplx fac)
+    {
+    Mat<V> res(std::move(A));
+    res *= fac;
+    return res;
+    }
+
+inline Mat<Cplx>
+operator*(Mat<Real> const& A, Cplx fac)
+    {
+    auto nr = nrows(A);
+    auto nc = ncols(A);
+    Mat<Cplx> res(nr,nc);
+    auto resend = res.data()+res.size();
+    auto Adata = A.data();
+    for(auto r = res.data(); r != resend; ++r, ++Adata)
+        *r = fac * (*Adata);
+    return res;
+    }
+
+template<typename V>
 Mat<V> 
 operator*(Real fac, Mat<V> && A)
     { 
@@ -72,6 +109,10 @@ operator*(Real fac, Mat<V> && A)
     res *= fac; 
     return res; 
     }
+
+template<typename V>
+Mat<common_type<V,Cplx>>
+operator*(Cplx fac, Mat<V> const& A) { return A*fac; }
 
 template<typename MatA,
          class = stdx::require<hasMatRange<MatA>> >

--- a/unittest/matrix_test.cc
+++ b/unittest/matrix_test.cc
@@ -1411,6 +1411,58 @@ SECTION("diagHermitian")
         }
     }
 
+SECTION("expMatrix")
+    {
+    auto N = 10;
+    auto M = randomMat(N,N);
+    M = M+transpose(M);
+    auto t = 2.0;
+    auto Mc = randomMatC(N,N);
+    Mc = Mc+conj(transpose(Mc));
+    auto tc = 1.0+2.0_i;
+
+    SECTION("Real Matrix")
+        {
+        auto expM = expMatrix(M);
+        auto expM2 = expHermitian(M);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Complex Matrix")
+        {
+        auto expM = expMatrix(Mc);
+        auto expM2 = expHermitian(Mc);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Real Matrix, Real Scalar")
+        {
+        auto expM = expMatrix(M,t);
+        auto expM2 = expHermitian(M,t);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Real Matrix, Complex Scalar")
+        {
+        auto expM = expMatrix(M,tc);
+        auto expM2 = expHermitian(M,tc);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Complex Matrix, Real Scalar")
+        {
+        auto expM = expMatrix(Mc,t);
+        auto expM2 = expHermitian(Mc,t);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Complex Matrix, Complex Scalar")
+        {
+        auto expM = expMatrix(Mc,tc);
+        auto expM2 = expHermitian(Mc,tc);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+    }
 
 //SECTION("diagHermitian")
 //    {


### PR DESCRIPTION
When trying to make @alexwie's Krylov method for exponentiating an operator work with the latest version of ITensor, I noticed the `expGeneral` didn't work with Real inputs. This makes it work with Real/mixed inputs, as well as changes the interface a little bit.