### PR TITLE
Fix Cplx*MatRef<Real> -> Mat<Cplx>

### DIFF
--- a/itensor/tensor/mat.cc
+++ b/itensor/tensor/mat.cc
@@ -70,6 +70,27 @@ operator&=(MatrixRef const& a, MatrixRefc const& b)
         }
     }
 
+void
+operator&=(CMatrixRef const& a, MatrixRefc const& b)
+    {
+#ifdef DEBUG
+    if(!(nrows(b)==nrows(a) && ncols(b)==ncols(a)))
+        throw std::runtime_error("mismatched sizes in MatrixRef operator&=");
+#endif
+    auto assign = [](Cplx& x, Real y) { x = y; };
+    if(a.range()==b.range() && isContiguous(b))
+        {
+        auto pa = MAKE_SAFE_PTR(a.data(),a.store().size());
+        auto pae = MAKE_SAFE_PTR_OFFSET(a.data(),dim(a.range()),a.store().size());
+        auto pb = MAKE_SAFE_PTR(b.data(),b.store().size());
+        apply(pa,pae,pb,assign);
+        }
+    else
+        {
+        apply(a,b.cbegin(),assign);
+        }
+    }
+
 template<typename V>
 void 
 multReal(MatRef<V> const& M, Real fac)

--- a/itensor/tensor/mat.h
+++ b/itensor/tensor/mat.h
@@ -101,6 +101,9 @@ operator-=(CMatrixRef const& A, CMatrix && B);
 void
 operator&=(MatrixRef const& A, MatrixRefc const& B);
 
+void
+operator&=(CMatrixRef const& A, MatrixRefc const& B);
+
 //Copy data of B to memory referenced by A
 void inline
 operator&=(MatrixRef const& A, Matrix const& B) { A &= makeRefc(B); }

--- a/itensor/tensor/mat_impl.h
+++ b/itensor/tensor/mat_impl.h
@@ -47,17 +47,17 @@ operator*(MatA const& A, Real fac)
 
 template<typename MatA,
          class = stdx::require<hasMatRange<MatA>> >
-Mat<val_type<MatA>>
+Mat<common_type<val_type<MatA>,Cplx>>
 operator*(MatA const& A, Cplx fac)
     {
-    Mat<val_type<MatA>> res(A);
+    Mat<common_type<val_type<MatA>,Cplx>> res(A);
     res *= fac;
     return res;
     }
 
 template<typename MatA,
          class = stdx::require<hasMatRange<MatA>> >
-Mat<val_type<MatA>>
+Mat<common_type<val_type<MatA>,Cplx>>
 operator*(Cplx fac, MatA const& A) { return A*fac; }
 
 template<typename MatA,

--- a/itensor/tensor/ten.h
+++ b/itensor/tensor/ten.h
@@ -544,6 +544,11 @@ class Ten : public TensorType
     explicit
     Ten(TenRefc<R,value_type> const& ref) { assignFromRef(ref); }
 
+    // To cover case like Mat<Cplx>(A) where A is Mat<Real>
+    template<typename R, typename T>
+    explicit
+    Ten(TenRefc<R,T> const& ref) { assignFromRef(ref); }
+
     template<typename R>
     Ten&
     operator=(TenRefc<R,value_type> const& ref) { assignFromRef(ref); return *this; }
@@ -688,6 +693,16 @@ class Ten : public TensorType
         data_.resize(dim(range_));
         makeRef(*this) &= ref;
         }
+
+    template<typename R, typename T>
+    void
+    assignFromRef(TenRefc<R,T> const& ref)
+        {
+        range_ = normalRange(ref.range());
+        data_.resize(dim(range_));
+        makeRef(*this) &= ref;
+        }
+
     };
 
 template<typename R, typename T, typename... VArgs>

--- a/unittest/matrix_test.cc
+++ b/unittest/matrix_test.cc
@@ -1462,6 +1462,39 @@ SECTION("expMatrix")
         auto expM2 = expHermitian(Mc,tc);
         CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
         }
+
+    SECTION("Real subMatrix, Real Scalar")
+        {
+        auto Ms = subMatrix(M,0,N-1,0,N-1);
+        auto expM = expMatrix(Ms,t);
+        auto expM2 = expHermitian(Ms,t);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Real subMatrix, Complex Scalar")
+        {
+        auto Ms = subMatrix(M,0,N-1,0,N-1);
+        auto expM = expMatrix(Ms,tc);
+        auto expM2 = expHermitian(Ms,tc);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Complex subMatrix, Real Scalar")
+        {
+        auto Ms = subMatrix(Mc,0,N-1,0,N-1);
+        auto expM = expMatrix(Ms,t);
+        auto expM2 = expHermitian(Ms,t);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
+    SECTION("Complex subMatrix, Complex Scalar")
+        {
+        auto Ms = subMatrix(Mc,0,N-1,0,N-1);
+        auto expM = expMatrix(Ms,tc);
+        auto expM2 = expHermitian(Ms,tc);
+        CHECK(norm(expM-expM2) < 1E-12*norm(expM2));
+        }
+
     }
 
 //SECTION("diagHermitian")


### PR DESCRIPTION
This fixes `Cplx*MatRef<Real> -> Mat<Cplx>`, which failed because conversion from `MatRef<Real>` to `Mat<Cplx>` wasn't defined.