### PR TITLE
Use PWD instead of CURDIR to create this_dir.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ itensor: configure
 configure:
 	@echo
 	@echo Configure: Writing current dir to this_dir.mk
-	@echo "THIS_DIR=${CURDIR}" > this_dir.mk
+	@echo "THIS_DIR=$(PWD)" > this_dir.mk
 	@echo "#ifndef __ITENSOR_CONFIG_H" > itensor/config.h
 	@echo "#define __ITENSOR_CONFIG_H" >> itensor/config.h
 	@echo "" >> itensor/config.h


### PR DESCRIPTION
This uses PWD instead of CURDIR to create the ITensor path stored in this_dir.mk.

In general, this shouldn't change anything, except in the case when the current path is a symlink. For some reason, CURDIR expands to the original location that is linked to. PWD prints the symlink location.

The reason the PWD behavior is better is because this gives a way around the issue that the build process fails if the path of the itensor library has a space in it. If the path has a space (which is unavoidable in certain cases, like in a dropbox folder), we can recommend to people to symlink to a location where the path has no spaces. This fixes the problem that Nils had building ITensor in a dropbox folder.

We should probably add a note about this issue in the ITensor installation instructions, and recommend using a symlink as a workaround.