### PR TITLE
Position bugfix

### DIFF
--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -663,7 +663,14 @@ position(int i, Args args)
             // Store the original tags for link b so that it can
             // be put back onto the newly introduced link index
             auto original_link_tags = tags(linkIndex(*this,b));
-            orthMPS(ref(b),ref(b+1),Fromright,{args,"LeftTags=",original_link_tags});
+            args.add("LeftTags=",original_link_tags);
+            if(original_link_tags == TagSet("Link,V,0"))
+                {
+                // Using LeftTags=Link,V will conflict with
+                // default right tags of svd (within orthMPS)
+                args.add("LeftTags=","Link");
+                }
+            orthMPS(ref(b),ref(b+1),Fromright,args);
 
             --r_orth_lim_;
             if(l_orth_lim_ > r_orth_lim_-2) l_orth_lim_ = r_orth_lim_-2;

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -586,7 +586,7 @@ struct Sqrt
     };
 
 Spectrum
-orthMPS(ITensor& A1, ITensor& A2, Direction dir, const Args& args)
+orthMPS(ITensor& A1, ITensor& A2, Direction dir, Args const& args)
     {
     ITensor& L = (dir == Fromleft ? A1 : A2);
     ITensor& R = (dir == Fromleft ? A2 : A1);

--- a/itensor/mps/mps.h
+++ b/itensor/mps/mps.h
@@ -900,6 +900,9 @@ overlap(MPSType const& psi,
         MPSType const& phi, 
         Real& re, Real& im);
 
+Spectrum
+orthMPS(ITensor& A1, ITensor& A2, Direction dir, Args const& args);
+
 } //namespace itensor
 
 #include "mps_impl.h"

--- a/itensor/svd.cc
+++ b/itensor/svd.cc
@@ -141,6 +141,17 @@ svdImpl(ITensor const& A,
         auto uL = Index(m,litagset);
         auto vL = setTags(uL,ritagset);
 
+        if(uL == vL)
+            {
+            Print(uL);
+            Print(vL);
+            Print(litagset);
+            Print(primeLevel(litagset));
+            Print(ritagset);
+            Print(primeLevel(ritagset));
+            Error("Error: new inds uL, vL in svd identical with given tag sets");
+            }
+
         //Fix sign to make sure D has positive elements
         Real signfix = (A.scale().sign() == -1) ? -1 : +1;
         D = ITensor({uL,vL},

--- a/itensor/svd.cc
+++ b/itensor/svd.cc
@@ -82,7 +82,10 @@ svdImpl(ITensor const& A,
     auto show_eigs = args.getBool("ShowEigs",false);
     auto litagset = getTagSet(args,"LeftTags","Link,U");
     auto ritagset = getTagSet(args,"RightTags","Link,V");
-    if( litagset == ritagset ) Error("In SVD, must specify different tags for the new left and right indices (with Args 'LeftTags' and 'RightTags')");
+    if(litagset == ritagset) 
+        {
+        Error("In SVD, must specify different tags for the new left and right indices (with Args 'LeftTags' and 'RightTags')");
+        }
 
     if(not hasQNs(A))
         {


### PR DESCRIPTION
Fix for bug found by Alexios M. The bug was caused by the logic of the position method setting LeftTags going into orthMPS (and thus into svd) to equal the default right tags.

By the way, there is a check within svd for this situation which fails, because TagSets can easily end up with negative prime level versus zero prime level depending on how they are constructed (from Args versus the TagSet constructor). Even though they are interpreted as both having prime level zero, the operator== comparison treats them as different.