### PR TITLE
Allow other storage types for block index in block-offsets

### DIFF
--- a/itensor/decomp.cc
+++ b/itensor/decomp.cc
@@ -1119,7 +1119,7 @@ qrImpl(ITensor const& A,
 	      int Rrows = nrows(RR) > ncols(RR) ? ncols(RR) : nrows(RR);
 	      int fillrows = nrows(QQ) - Rrows;
 	      
-	      auto qind = Labels(2);
+	      auto qind = Block(2);
 	      qind[0] = B.i1;
 	      qind[1] = n;
 	      auto pQ = getBlock(Qstore,Qis,qind);
@@ -1130,7 +1130,7 @@ qrImpl(ITensor const& A,
 	      //Filler columns of Q due to reshuffling to make uppertriangular
 	      if (uppertriangular and complete and fillrows > 0)
 		{
-		  auto qfind = Labels(2);
+		  auto qfind = Block(2);
 		  qfind[0] = B.i1;
 		  qfind[1] =  extrab + Nblock;
 		  auto pQf = getBlock(Qstore,Qis,qfind);
@@ -1140,7 +1140,7 @@ qrImpl(ITensor const& A,
 		  extrab++;
 		}
 	      
-	      auto rind =  Labels(2);
+	      auto rind = Block(2);
 	      rind[0] = n;
 	      rind[1] = B.i2;
 	      auto pR = getBlock(Rstore,Ris,rind);
@@ -1154,7 +1154,7 @@ qrImpl(ITensor const& A,
 	  {
 	    for (const auto& b : zerob)
 	      {
-		auto sqind =  Labels(2);
+		auto sqind = Block(2);
 		sqind[0] = b;
 		sqind[1] = extrab + Nblock;
 		auto psQ = getBlock(Qstore,Qis,sqind);

--- a/itensor/hermitian.cc
+++ b/itensor/hermitian.cc
@@ -383,7 +383,7 @@ diagHImpl(ITensor H,
             //to this_m==0 case above
             if(not B.M) continue;
 
-            auto uind = Labels(2);
+            auto uind = Block(2);
             uind[0] = B.i1;
             uind[1] = n;
             auto pU = getBlock(Ustore,Uis,uind);
@@ -392,7 +392,7 @@ diagHImpl(ITensor H,
             auto Uref = makeMatRef(pU,nrows(UU),mm);
             Uref &= UU;
 
-            auto dind = Labels(2);
+            auto dind = Block(2);
             dind[0] = n;
             dind[1] = n;
             auto pD = getBlock(Dstore,Dis,dind);

--- a/itensor/itdata/qdiag.cc
+++ b/itensor/itdata/qdiag.cc
@@ -383,9 +383,9 @@ blockDiagDense(QDiag<VD> const& D,
 
         auto do_contract =
             [&D,&Dis,&Tis,&Cis,&DL,&TL,&CL]
-            (DataRange<const VT> tblock, IntArray const& Tblockind,
-             DataRange<const VD> dblock, IntArray const& Dblockind,
-             DataRange<VC>       cblock, IntArray const& Cblockind)
+            (DataRange<const VT> tblock, Block const& Tblockind,
+             DataRange<const VD> dblock, Block const& Dblockind,
+             DataRange<VC>       cblock, Block const& Cblockind)
             {
             Range Trange,
                   Crange;
@@ -439,9 +439,9 @@ blockDiagDense(QDiag<VD> const& D,
 
         auto do_contract =
             [&D,&Dis,&Tis,&DL,&TL,&CL]
-            (DataRange<const VT> tblock, IntArray const& Tblockind,
-             DataRange<const VD> dblock, IntArray const& Dblockind,
-             DataRange<VC>       cblock, IntArray const& Cblockind)
+            (DataRange<const VT> tblock, Block const& Tblockind,
+             DataRange<const VD> dblock, Block const& Dblockind,
+             DataRange<VC>       cblock, Block const& Cblockind)
             {
             Range Trange;
             Trange.init(make_indexdim(Tis,Tblockind));

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -548,9 +548,9 @@ template<typename V>
 struct GetBlock
     {
     IndexSet const& is;
-    IntArray const& block_ind;
+    Block const& block_ind;
     GetBlock(IndexSet const& is_,
-             IntArray const& bi)
+             Block const& bi)
         : is(is_), block_ind(bi) { }
     };
 inline const char*

--- a/itensor/itensor.h
+++ b/itensor/itensor.h
@@ -1034,7 +1034,7 @@ removeQNs(ITensor T);
 
 template<typename V>
 TenRef<Range,V>
-getBlock(ITensor & T, IntArray block_ind);
+getBlock(ITensor & T, Block block_ind);
 
 std::ostream& 
 operator<<(std::ostream & s, ITensor const& T);

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -580,7 +580,7 @@ diagITensor(Container const& C,
 template<typename V>
 TenRef<Range,V>
 getBlock(ITensor & T,
-         IntArray block_ind)
+         Block block_ind)
     {
     if(block_ind.size() != size_t(T.order())) Error("Mismatched number of indices and ITensor order");
     if(not T.store())

--- a/itensor/svd.cc
+++ b/itensor/svd.cc
@@ -357,7 +357,7 @@ svdImpl(ITensor const& A,
             //printfln("{n,n} = {%d,%d}",n,n);
             //printfln("{B.i2,n} = {%d,%d}",B.i2,n);
 
-            auto uind = Labels(2);
+            auto uind = Block(2);
             uind[0] = B.i1;
             uind[1] = n;
             auto pU = getBlock(Ustore,Uis,uind);
@@ -367,7 +367,7 @@ svdImpl(ITensor const& A,
             reduceCols(UU,L.blocksize0(n));
             Uref &= UU;
 
-            auto dind = Labels(2);
+            auto dind = Block(2);
             dind[0] = n;
             dind[1] = n;
             auto pD = getBlock(Dstore,Dis,dind);
@@ -375,7 +375,7 @@ svdImpl(ITensor const& A,
             auto Dref = makeVecRef(pD.data(),d.size());
             Dref &= d;
 
-            auto vind = Labels(2);
+            auto vind = Block(2);
             vind[0] = B.i2;
             vind[1] = n;
             auto pV = getBlock(Vstore,Vis,vind);

--- a/itensor/tensor/types.h
+++ b/itensor/tensor/types.h
@@ -207,7 +207,9 @@ sliceData(DataRange<T> d, size_t begin, size_t end)
 // Types to help with block sparse data
 //
 
-using Block = Labels;
+using Block = InfArray<long,11ul>;
+// Maybe try this for better memory?
+//using Block = std::vector<unsigned short>;
 
 // Define a block ordering according to (reverse)
 // lexicographical order


### PR DESCRIPTION
Make sure to use `Block` everywhere block-offsets are used so it is easy to switch out other storage types for `Block` (right now it is defined as `InfArray<long,11ul>` but if we are worried about storage size we could try smaller integer types).