### PR TITLE
makeCplx() method for ITensors

### DIFF
--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -131,6 +131,18 @@ template
 void
 doTask(Mult<Real> const& M, DenseCplx & D);
 
+void
+doTask(MakeComplex const&, Dense<Cplx> & D)
+    {
+    //do nothing, already complex
+    }
+void
+doTask(MakeComplex const&, Dense<Real> const& D, ManageStore & m)
+    {
+    //convert data to complex
+    m.makeNewData<DenseCplx>(D.begin(),D.end());
+    }
+
 template<typename T>
 Real
 doTask(NormNoScale, Dense<T> const& D) 

--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -132,12 +132,12 @@ void
 doTask(Mult<Real> const& M, DenseCplx & D);
 
 void
-doTask(MakeComplex const&, Dense<Cplx> & D)
+doTask(MakeCplx const&, Dense<Cplx> & D)
     {
     //do nothing, already complex
     }
 void
-doTask(MakeComplex const&, Dense<Real> const& D, ManageStore & m)
+doTask(MakeCplx const&, Dense<Real> const& D, ManageStore & m)
     {
     //convert data to complex
     m.makeNewData<DenseCplx>(D.begin(),D.end());
@@ -194,12 +194,6 @@ doTask(TakeImag, DenseCplx const& D, ManageStore & m)
         {
         nD[n] = D[n].imag();
         }
-    }
-
-void
-doTask(MakeCplx, DenseReal const& d, ManageStore & m)
-    {
-    m.makeNewData<DenseCplx>(d.begin(),d.end());
     }
 
 

--- a/itensor/itdata/dense.h
+++ b/itensor/itdata/dense.h
@@ -250,6 +250,11 @@ doTask(Mult<Cplx> const& f, Dense<Real> const& D, ManageStore & m);
 void
 doTask(Mult<Cplx> const& f, Dense<Cplx> & D);
 
+void
+doTask(MakeComplex const&, Dense<Real> & D);
+void
+doTask(MakeComplex const&, Dense<Cplx> & D);
+
 template<typename T>
 Real
 doTask(NormNoScale, Dense<T> const& d);

--- a/itensor/itdata/dense.h
+++ b/itensor/itdata/dense.h
@@ -251,9 +251,9 @@ void
 doTask(Mult<Cplx> const& f, Dense<Cplx> & D);
 
 void
-doTask(MakeComplex const&, Dense<Real> & D);
+doTask(MakeCplx const&, Dense<Cplx> & D);
 void
-doTask(MakeComplex const&, Dense<Cplx> & D);
+doTask(MakeCplx const&, Dense<Real> const& d, ManageStore & m);
 
 template<typename T>
 Real
@@ -276,12 +276,6 @@ doTask(TakeImag, DenseReal & d);
 
 void
 doTask(TakeImag, DenseCplx const& d, ManageStore & m);
-
-void
-doTask(MakeCplx, DenseReal const& d, ManageStore & m);
-
-void inline
-doTask(MakeCplx, DenseCplx const& d) { }
 
 template<typename T>
 bool constexpr

--- a/itensor/itdata/qdense.cc
+++ b/itensor/itdata/qdense.cc
@@ -323,6 +323,17 @@ doTask(Mult<Cplx> const& M, QDense<Real> const& d, ManageStore & m)
     doTask(M,*nd);
     }
 
+void
+doTask(MakeCplx const&, QDense<Cplx> & d)
+    {
+    //nothing to do
+    }
+void
+doTask(MakeCplx const&, QDense<Real> const& d, ManageStore & m)
+    {
+    m.makeNewData<QDenseCplx>(d.offsets,d.begin(),d.end());
+    }
+
 template<typename T>
 int
 doTask(NNZBlocks, QDense<T> const& D)

--- a/itensor/itdata/qdense.h
+++ b/itensor/itdata/qdense.h
@@ -342,6 +342,12 @@ doTask(Mult<Cplx> const& M, QDense<Real> const& d, ManageStore & m);
 void
 doTask(Mult<Cplx> const& M, QDense<Cplx> & d);
 
+void
+doTask(MakeCplx const&, QDense<Cplx> & d);
+     
+void
+doTask(MakeCplx const&, QDense<Real> const& d, ManageStore & m);
+
 template<typename T>
 void
 doTask(Fill<T> const& F, QDense<T> & d);

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -38,6 +38,13 @@ template<typename T>
 const char*
 typeNameOf(Mult<T> const&) { return "Mult"; }
 
+
+struct MakeComplex { };
+
+const char*
+typeNameOf(MakeComplex const&) { return "MakeComplex"; }
+
+
 struct GetElt
     {
     IndexSet const& is;

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -39,10 +39,10 @@ const char*
 typeNameOf(Mult<T> const&) { return "Mult"; }
 
 
-struct MakeComplex { };
+struct MakeCplx { };
 
-const char*
-typeNameOf(MakeComplex const&) { return "MakeComplex"; }
+inline const char*
+typeNameOf(MakeCplx const&) { return "MakeCplx"; }
 
 
 struct GetElt
@@ -286,7 +286,6 @@ typeNameOf(Fill<T> const&) { return "Fill"; }
 
 struct TakeReal { };
 struct TakeImag { };
-struct MakeCplx { };
 
 inline const char*
 typeNameOf(TakeReal const&) { return "TakeReal"; }

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -268,6 +268,12 @@ takeImag()
     return *this;
     }
 
+ITensor& ITensor::
+makeCplx()
+    {
+    doTask(MakeCplx{},store_);
+    return *this;
+    }
 
 ITensor& ITensor::
 randomize(Args const& args)

--- a/itensor/itensor.h
+++ b/itensor/itensor.h
@@ -323,6 +323,10 @@ class ITensor
     ITensor&
     takeImag();
 
+    //Force storage to be complex-valued
+    ITensor&
+    makeCplx();
+
     //
     // Operators
     //


### PR DESCRIPTION
This PR implements the T.makeCplx() method for an ITensor T. It works for ITensors with Dense and QDense storage.