### PR TITLE
Replace some zero vector initializations from contract and gemm_emmul…

### DIFF
--- a/itensor/tensor/contract.cc
+++ b/itensor/tensor/contract.cc
@@ -747,7 +747,7 @@ contract(CProps const& p,
     auto Bbufsize = isCplx(B) ? 2ul*Bpsize : Bpsize;
     auto Cbufsize = isCplx(C) ? 2ul*Cpsize : Cpsize;
 
-    auto d = std::vector<Real>(Abufsize+Bbufsize+Cbufsize);
+    auto d = vector_no_init<Real>(Abufsize+Bbufsize+Cbufsize);
     auto ab = MAKE_SAFE_PTR(d.data(),d.size());
     auto bb = ab+Abufsize;
     auto cb = bb+Bbufsize;

--- a/itensor/tensor/gemm.cc
+++ b/itensor/tensor/gemm.cc
@@ -98,7 +98,7 @@ gemm_emulator(MatRefc<VA> A,
     auto Brd = SAFE_REINTERPRET(const Real,Bd);
     auto Crd = SAFE_REINTERPRET(Real,Cd);
 
-    auto d = std::vector<Real>(Abufsize+Bbufsize+Cbufsize);
+    auto d = vector_no_init<Real>(Abufsize+Bbufsize+Cbufsize);
     auto pd = MAKE_SAFE_PTR(d.data(),d.size());
     auto ab = pd;
     auto ae = ab+Abufsize;


### PR DESCRIPTION
…ator.

This makes tensor contraction slightly faster (for Daniel's fork tensor product state, I saw about 5-7% speedups).