### PR TITLE
Quickran fix potential overflow

### DIFF
--- a/itensor/detail/algs.h
+++ b/itensor/detail/algs.h
@@ -98,7 +98,7 @@ quickran()
     auto res = 0.0;
     while(res == 0.0)
         {
-        long& seed = seed_quickran(0);
+        long seed = seed_quickran(0);
         long im = 134456;
         long ia = 8121;
         long ic = 28411;

--- a/itensor/detail/algs.h
+++ b/itensor/detail/algs.h
@@ -98,10 +98,10 @@ quickran()
     auto res = 0.0;
     while(res == 0.0)
         {
-        auto& seed = seed_quickran(0);
-        int im = 134456;
-        int ia = 8121;
-        int ic = 28411;
+        long& seed = seed_quickran(0);
+        long im = 134456;
+        long ia = 8121;
+        long ic = 28411;
         double scale = 1.0 / im;
         seed = (seed*ia+ic)%im;
         res = std::fabs(double(seed)) * scale;

--- a/itensor/detail/algs.h
+++ b/itensor/detail/algs.h
@@ -84,10 +84,10 @@ contains(const Container& C,
     }
 
 //Simple linear congruential random number generator
-inline int&
+inline long&
 seed_quickran(int newseed)
     {
-    static int seed = (std::time(NULL) + getpid());
+    static long seed = (std::time(NULL) + getpid());
     if(newseed != 0) seed = newseed;
     return seed;
     }
@@ -98,7 +98,7 @@ quickran()
     auto res = 0.0;
     while(res == 0.0)
         {
-        long seed = seed_quickran(0);
+        long& seed = seed_quickran(0);
         long im = 134456;
         long ia = 8121;
         long ic = 28411;


### PR DESCRIPTION
Nils pointed out from a sanitizer check that quickran might have an integer overflow issue. I've extended the integer types to long to (hopefully) fix this, though it is hard to check since it is based on a generated process id.