### PR TITLE
Add support for LAPACK SVD routines

### DIFF
--- a/itensor/svd.cc
+++ b/itensor/svd.cc
@@ -73,7 +73,6 @@ svdImpl(ITensor const& A,
       }
 
     auto do_truncate = args.getBool("Truncate");
-    auto thresh = args.getReal("SVDThreshold",1E-3);
     auto cutoff = args.getReal("Cutoff",MIN_CUT);
     auto maxdim = args.getInt("MaxDim",MAX_DIM);
     auto mindim = args.getInt("MinDim",1);
@@ -94,7 +93,7 @@ svdImpl(ITensor const& A,
         Mat<T> UU,VV;
         Vector DD;
 
-        SVD(M,UU,DD,VV,thresh);
+        SVD(M,UU,DD,VV,args);
 
         //conjugate VV so later we can just do
         //U*D*V to reconstruct ITensor A:
@@ -215,7 +214,7 @@ svdImpl(ITensor const& A,
             auto& VV = Vmats.at(b);
             auto& d =  dvecs.at(b);
 
-            SVD(M,UU,d,VV,thresh);
+            SVD(M,UU,d,VV,args);
 
             //conjugate VV so later we can just do
             //U*D*V to reconstruct ITensor A:

--- a/itensor/tensor/algs.h
+++ b/itensor/tensor/algs.h
@@ -17,6 +17,7 @@
 #define __ITENSOR_MATRIX_ALGS__H_
 
 #include "itensor/tensor/slicemat.h"
+#include "itensor/util/args.h"
 
 namespace itensor {
 
@@ -114,7 +115,7 @@ SVD(MatM && M,
     MatU && U, 
     VecD && D, 
     MatV && V,
-    Real thresh = SVD_THRESH);
+    const Args & args = Args::global() );
 
   
 //

--- a/itensor/tensor/lapack_wrap.cc
+++ b/itensor/tensor/lapack_wrap.cc
@@ -366,15 +366,18 @@ zgesdd_wrapper(char *jobz,           //char* specifying how much of U, V to comp
                                      //choosing *jobz=='S' computes min(m,n) cols of U, V
                LAPACK_INT *m,        //number of rows of input matrix *A
                LAPACK_INT *n,        //number of cols of input matrix *A
-               LAPACK_COMPLEX *A,    //contents of input matrix A
+               Cplx *A,    //contents of input matrix A
                LAPACK_REAL *s,       //on return, singular values of A
-               LAPACK_COMPLEX *u,    //on return, unitary matrix U
-               LAPACK_COMPLEX *vt,   //on return, unitary matrix V transpose
+               Cplx *u,    //on return, unitary matrix U
+               Cplx *vt,   //on return, unitary matrix V transpose
                LAPACK_INT *info)
     {
     std::vector<LAPACK_COMPLEX> work;
     std::vector<LAPACK_REAL> rwork;
     std::vector<LAPACK_INT> iwork;
+    auto pA = reinterpret_cast<LAPACK_COMPLEX*>(A);
+    auto pU = reinterpret_cast<LAPACK_COMPLEX*>(u);
+    auto pVt = reinterpret_cast<LAPACK_COMPLEX*>(vt);
     LAPACK_INT l = std::min(*m,*n),
                g = std::max(*m,*n);
     LAPACK_INT lwork = l*l+2*l+g+100;
@@ -383,9 +386,101 @@ zgesdd_wrapper(char *jobz,           //char* specifying how much of U, V to comp
     iwork.resize(8*l);
 #ifdef PLATFORM_acml
     LAPACK_INT jobz_len = 1;
-    F77NAME(zgesdd)(jobz,m,n,A,m,s,u,m,vt,n,work.data(),&lwork,rwork.data(),iwork.data(),info,jobz_len);
+    F77NAME(zgesdd)(jobz,m,n,pA,m,s,pU,m,pVt,n,work.data(),&lwork,rwork.data(),iwork.data(),info,jobz_len);
 #else
-    F77NAME(zgesdd)(jobz,m,n,A,m,s,u,m,vt,n,work.data(),&lwork,rwork.data(),iwork.data(),info);
+    F77NAME(zgesdd)(jobz,m,n,pA,m,s,pU,m,pVt,n,work.data(),&lwork,rwork.data(),iwork.data(),info);
+#endif
+    }
+
+
+
+  void 
+dgesdd_wrapper(char* jobz,           //char* specifying how much of U, V to compute
+                                    //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT *m,        //number of rows of input matrix *A
+               LAPACK_INT *n,        //number of cols of input matrix *A
+               LAPACK_REAL *A,      //contents of input matrix A
+               LAPACK_REAL *s,      //on return, singular values of A
+               LAPACK_REAL *u,           //on return, unitary matrix U
+               LAPACK_REAL *vt,          //on return, unitary matrix V transpose
+               LAPACK_INT *info)
+    {
+    std::vector<LAPACK_REAL> work;
+    std::vector<LAPACK_INT> iwork;
+    LAPACK_INT l = std::min(*m,*n),
+               g = std::max(*m,*n);
+    LAPACK_INT lwork = l*(6 + 4*l) + g;
+    work.resize(lwork);
+    iwork.resize(8*l);
+#ifdef PLATFORM_acml
+    LAPACK_INT jobz_len = 1;
+    F77NAME(dgesdd)(jobz,m,n,A,m,s,u,m,vt,&l,work.data(),&lwork,iwork.data(),info,jobz_len);
+#else
+    F77NAME(dgesdd)(jobz,m,n,A,m,s,u,m,vt,&l,work.data(),&lwork,iwork.data(),info);
+#endif
+    }
+
+
+
+  void 
+zgesvd_wrapper(char *jobz,           //char* specifying how much of U, V to compute
+                                     //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT *m,        //number of rows of input matrix *A
+               LAPACK_INT *n,        //number of cols of input matrix *A
+               Cplx *A,    //contents of input matrix A
+               LAPACK_REAL *s,       //on return, singular values of A
+               Cplx *u,    //on return, unitary matrix U
+               Cplx *vt,   //on return, unitary matrix V transpose
+               LAPACK_INT *info)
+    {
+    std::vector<LAPACK_COMPLEX> work;
+    std::vector<LAPACK_REAL> rwork;
+    std::vector<LAPACK_INT> iwork;
+    auto pA = reinterpret_cast<LAPACK_COMPLEX*>(A);
+    auto pU = reinterpret_cast<LAPACK_COMPLEX*>(u);
+    auto pVt = reinterpret_cast<LAPACK_COMPLEX*>(vt);
+    LAPACK_INT l = std::min(*m,*n),
+               g = std::max(*m,*n);
+    LAPACK_INT lwork = l*l+2*l+g+100;
+    work.resize(lwork);
+    rwork.resize(5*l*(1+l));
+    iwork.resize(8*l);
+#ifdef PLATFORM_acml
+    LAPACK_INT jobz_len = 1;
+    F77NAME(zgesvd)(jobz,jobz,m,n,pA,m,s,pU,m,pVt,n,work.data(),&lwork,rwork.data(),info,jobz_len);
+#else
+    F77NAME(zgesvd)(jobz,jobz,m,n,pA,m,s,pU,m,pVt,n,work.data(),&lwork,rwork.data(),info);
+#endif
+    }
+
+
+
+  void 
+dgesvd_wrapper(char* jobz,           //char* specifying how much of U, V to compute
+                                    //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT *m,        //number of rows of input matrix *A
+               LAPACK_INT *n,        //number of cols of input matrix *A
+               LAPACK_REAL *A,      //contents of input matrix A
+               LAPACK_REAL *s,      //on return, singular values of A
+               LAPACK_REAL *u,           //on return, unitary matrix U
+               LAPACK_REAL *vt,          //on return, unitary matrix V transpose
+               LAPACK_INT *info)
+    {
+    std::vector<LAPACK_REAL> work;
+    // std::vector<LAPACK_REAL> superb;
+    
+    std::vector<LAPACK_INT> iwork;
+    LAPACK_INT l = std::min(*m,*n),
+               g = std::max(*m,*n);
+    LAPACK_INT lwork = l*(6 + 4*l) + g;
+    work.resize(lwork);
+    iwork.resize(8*l);
+    //superb.resize(l -1);
+#ifdef PLATFORM_acml
+    LAPACK_INT jobz_len = 1;
+    F77NAME(dgesvd)(jobz,jobz,m,n,A,m,s,u,m,vt,&l,work.data(),&lwork, info, jobz_len);
+#else
+    F77NAME(dgesvd)(jobz,jobz,m,n,A,m,s,u,m,vt,&l,work.data(),&lwork, info);
 #endif
     }
 

--- a/itensor/tensor/lapack_wrap.h
+++ b/itensor/tensor/lapack_wrap.h
@@ -297,6 +297,28 @@ void cblas_dscal(const LAPACK_INT N, const LAPACK_REAL alpha, LAPACK_REAL* X,con
 void F77NAME(dscal)(LAPACK_INT* N, LAPACK_REAL* alpha, LAPACK_REAL* X,LAPACK_INT* incX);
 #endif
 
+
+#ifdef PLATFORM_acml
+void F77NAME(dgesdd)(char *jobz, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
+             double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
+             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info, int jobz_len);
+#else
+void F77NAME(dgesdd)(char *jobz, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
+             double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
+             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info);
+#endif
+
+
+#ifdef PLATFORM_acml
+  void F77NAME(dgesvd)(char *jobz, char* jobv, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
+             double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
+             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info, int jobz_len);
+#else
+  void F77NAME(dgesvd)(char *jobz, char* jobv, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
+             double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
+             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info);
+#endif
+
 #ifdef PLATFORM_acml
 void F77NAME(zgesdd)(char *jobz, int *m, int *n, LAPACK_COMPLEX *a, int *lda, double *s, 
              LAPACK_COMPLEX *u, int *ldu, LAPACK_COMPLEX *vt, int *ldvt, 
@@ -527,16 +549,52 @@ dscal_wrapper(LAPACK_INT N,
               LAPACK_REAL* data,
               LAPACK_INT inc = 1);
 
+
+void
+dgesdd_wrapper(char * jobz,           //char* specifying how much of U, V to compute
+                                    //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT* m,       //number of rows of input matrix *A
+               LAPACK_INT* n,       //number of cols of input matrix *A
+               LAPACK_REAL *A,       //contents of input matrix A
+               LAPACK_REAL *s,       //on return, singular values of A
+               LAPACK_REAL *u,       //on return, unitary matrix U
+               LAPACK_REAL *vt,      //on return, unitary matrix V transpose
+               LAPACK_INT *info);
+
 void
 zgesdd_wrapper(char *jobz,           //char* specifying how much of U, V to compute
                                      //choosing *jobz=='S' computes min(m,n) cols of U, V
                LAPACK_INT *m,        //number of rows of input matrix *A
                LAPACK_INT *n,        //number of cols of input matrix *A
-               LAPACK_COMPLEX *A,    //contents of input matrix A
+               Cplx *A,    //contents of input matrix A
                LAPACK_REAL *s,       //on return, singular values of A
-               LAPACK_COMPLEX *u,    //on return, unitary matrix U
-               LAPACK_COMPLEX *vt,   //on return, unitary matrix V transpose
+               Cplx *u,    //on return, unitary matrix U
+               Cplx *vt,   //on return, unitary matrix V transpose
                LAPACK_INT *info);
+
+
+  void
+dgesvd_wrapper(char * jobz,           //char* specifying how much of U, V to compute
+                                    //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT* m,       //number of rows of input matrix *A
+               LAPACK_INT* n,       //number of cols of input matrix *A
+               LAPACK_REAL *A,       //contents of input matrix A
+               LAPACK_REAL *s,       //on return, singular values of A
+               LAPACK_REAL *u,       //on return, unitary matrix U
+               LAPACK_REAL *vt,      //on return, unitary matrix V transpose
+               LAPACK_INT *info);
+
+void
+zgesvd_wrapper(char *jobz,           //char* specifying how much of U, V to compute
+                                     //choosing *jobz=='S' computes min(m,n) cols of U, V
+               LAPACK_INT *m,        //number of rows of input matrix *A
+               LAPACK_INT *n,        //number of cols of input matrix *A
+               Cplx *A,    //contents of input matrix A
+               LAPACK_REAL *s,       //on return, singular values of A
+               Cplx *u,    //on return, unitary matrix U
+               Cplx *vt,   //on return, unitary matrix V transpose
+               LAPACK_INT *info);
+
 
 //
 // dgeqrf

--- a/itensor/tensor/lapack_wrap.h
+++ b/itensor/tensor/lapack_wrap.h
@@ -312,11 +312,22 @@ void F77NAME(dgesdd)(char *jobz, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK
 #ifdef PLATFORM_acml
   void F77NAME(dgesvd)(char *jobz, char* jobv, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
              double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
-             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info, int jobz_len);
+             double *work, LAPACK_INT *lwork, LAPACK_INT *info, int jobz_len);
 #else
   void F77NAME(dgesvd)(char *jobz, char* jobv, LAPACK_INT *m, LAPACK_INT *n, double *a, LAPACK_INT *lda, double *s, 
              double *u, LAPACK_INT *ldu, double *vt, LAPACK_INT *ldvt, 
-             double *work, LAPACK_INT *lwork, LAPACK_INT *iwork, LAPACK_INT *info);
+             double *work, LAPACK_INT *lwork, LAPACK_INT *info);
+#endif
+
+
+  #ifdef PLATFORM_acml
+  void F77NAME(zgesvd)(char *jobz, char* jobv, LAPACK_INT *m, LAPACK_INT *n, LAPACK_COMPLEX *a, LAPACK_INT *lda, LAPACK_REAL *s, 
+             LAPACK_COMPLEX *u, LAPACK_INT *ldu,  LAPACK_COMPLEX *vt, LAPACK_INT *ldvt, 
+             LAPACK_COMPLEX *work, LAPACK_INT *lwork, LAPACK_REAL * rwork, LAPACK_INT *info, int jobz_len);
+#else
+  void F77NAME(zgesvd)(char *jobz, char* jobv, LAPACK_INT *m, LAPACK_INT *n, LAPACK_COMPLEX *a, LAPACK_INT *lda, LAPACK_REAL *s, 
+             LAPACK_COMPLEX *u, LAPACK_INT *ldu, LAPACK_COMPLEX *vt, LAPACK_INT *ldvt, 
+		       LAPACK_COMPLEX *work, LAPACK_INT *lwork, LAPACK_REAL * rwork, LAPACK_INT *info);
 #endif
 
 #ifdef PLATFORM_acml


### PR DESCRIPTION
Adds an optional argument to svd "SVDMethod", allowing the selection of either the ITensor implementation "ITensor", the divide-and-conquer LAPACK method "gesdd" or the QR LAPACK method "gesvd". Effectively #179 updated to ITensor v3, with gesvd, and slightly reorganised to avoid code duplication when calling multiple different SVD routines, so full credit to @jurajHasik for the majority of the code (I only didn't build on top because pulling their branch onto v3 merged in some unrelated v2 stuff as well).

Use Cases: Benchmarking, both of the ITensor routine and against other MPS/DMRG codes which often implicitly use gesdd through their languages' SVDs (e.g. numpy, Julia). [This is why I personally needed this.] Also, both gesdd and gesvd seem much faster and more accurate (see attached graphs based on 1000 runs of the "Accuracy Stress Test" unit test in ITensor on a matrix with rapidly decreasing s.v.s with a single thread (MKL)), so unless the matrices are pathological it would seem to make sense to use gesdd, or gesvd if that fails (see discussion about gesvd vs gesdd e.g. here: https://discourse.julialang.org/t/svd-better-default-to-gesvd-instead-of-gesdd/20603)

Notes: Currently would break any user code which called the thresh argument explicitly, but could easily be fixed with an overload to not do so if this is a problem -- I'm not sure if that argument is user-facing anyway? On the subject, the default in the old code is currently SVD_THRESH = 1e-5 for matrices and 1e-3 for ITensors (from auto thresh = args.getReal("SVDThreshold",1E-3)) -- which is more sensible?

![svderrors](https://user-images.githubusercontent.com/26630266/75394392-de8ec200-58a4-11ea-9d99-31e2a4742f8f.png)

![svdtimes](https://user-images.githubusercontent.com/26630266/75394403-e2badf80-58a4-11ea-9b8e-b9566fcc67ec.png)




