### PR TITLE
Relpace orthog in SVD with QR

### DIFF
--- a/itensor/decomp.cc
+++ b/itensor/decomp.cc
@@ -1016,7 +1016,7 @@ qrImpl(ITensor const& A,
 
         Mat<T> QQ,RR;
 
-        QR(matA, QQ, RR, complete);
+        QR(matA, QQ, RR, args);
         
         auto qL = Index(nrows(RR),internaltagset);
         auto rL = setTags(qL,internaltagset);
@@ -1054,7 +1054,7 @@ qrImpl(ITensor const& A,
 	      zerob.erase(B.i1);
 	      auto & QQ = Qmats.at(b);
 	      auto & RR = Rmats.at(b);
-	      QR(matA, QQ, RR, complete);
+	      QR(matA, QQ, RR, args);
 	      if (uppertriangular)
 		{
 		  int subQcols = nrows(RR) > ncols(RR) ? ncols(RR) : nrows(RR);

--- a/itensor/tensor/algs.cc
+++ b/itensor/tensor/algs.cc
@@ -558,18 +558,10 @@ SVDRefImpl(MatRefc<T> const& M,
 
 
     QR(V, tempV, R, {"Complete", false, "PositiveDiagonal", true});
-
-    //Sort diagonal into descending order
-    auto diag = diagonal(R);
-    std::vector<long unsigned int> idx(diag.size());
-    std::iota(idx.begin(), idx.end(), 0);
-    std::sort(idx.begin(), idx.end(),
-	      [&diag](long unsigned int i1, long unsigned int i2)
-	      {return std::real(diag(i1)) > std::real(diag(i2));});
-    for(long unsigned int i = 0; i < diag.size(); i++)
+    V &= std::move(tempV);
+    for(long unsigned int i = 0; i < D.size(); i++)
       {
-	D(i) = std::real(diag(idx[i]));
-	column(V,i) &= column(tempV, idx[i]);
+	D(i) = std::real(R(i,i));
       }
 
     bool done = false;

--- a/itensor/tensor/algs.h
+++ b/itensor/tensor/algs.h
@@ -133,7 +133,7 @@ void
 QR(MatA && A,
    MatQ && Q,
    MatR && R,
-   bool complete = true);
+   const Args & args = Args::global());
 
 //
 // Hermitian Matrix exponentiate

--- a/itensor/tensor/algs_impl.h
+++ b/itensor/tensor/algs_impl.h
@@ -15,7 +15,6 @@
 //
 #ifndef __ITENSOR_MATRIX_ALGS_IMPL_H_
 #define __ITENSOR_MATRIX_ALGS_IMPL_H_
-#include "itensor/global.h"
 
 namespace itensor {
 

--- a/itensor/tensor/algs_impl.h
+++ b/itensor/tensor/algs_impl.h
@@ -15,6 +15,7 @@
 //
 #ifndef __ITENSOR_MATRIX_ALGS_IMPL_H_
 #define __ITENSOR_MATRIX_ALGS_IMPL_H_
+#include "itensor/global.h"
 
 namespace itensor {
 
@@ -289,8 +290,11 @@ void
 QR( MatA&& A,
     MatQ && Q,
     MatR && R,
-    bool complete)
+    const Args & args)
    {
+
+     auto complete = args.getBool("Complete", false);
+     auto positive = args.getBool("PositiveDiagonal", false);
     using Aval = typename stdx::decay_t<MatA>::value_type;
     using Qval = typename stdx::decay_t<MatQ>::value_type;
     static_assert((isReal<Aval>() && isReal<Qval>()) || (isCplx<Aval>() && isCplx<Qval>()),
@@ -332,6 +336,19 @@ QR( MatA&& A,
         }
     if(N > M)
       reduceCols(Q,M);
+    if (positive)
+      {
+	const int diagSize = Rrows < N ? Rrows : N;
+	for (int i = 0; i < diagSize; i++)
+	  {
+	  if(std::real(R(i,i)) < 0)
+	    {
+	      row(R, i) *= -1.;
+	      column(Q,i) *= -1.;
+	    }
+	 
+	  }
+      }
    }
 
 

--- a/unittest/matrix_test.cc
+++ b/unittest/matrix_test.cc
@@ -1423,7 +1423,7 @@ SECTION("diagHermitian")
 	auto Id = eye(N, N);
 
         Matrix Q, R;
-        QR(M,Q,R, true);
+        QR(M,Q,R, {"Complete", true});
 
         auto T = Q*R;
 	auto QQ = Q*transpose(Q);
@@ -1445,7 +1445,7 @@ SECTION("diagHermitian")
 	auto Id = eye(P, P);
 
         Matrix Q, R;
-        QR(M,Q,R, true);
+        QR(M,Q,R, {"Complete", true});
 
         auto T = Q*R;
 	auto QQ = Q*transpose(Q);
@@ -1461,13 +1461,38 @@ SECTION("diagHermitian")
 	CHECK(norm(QQ-Id) <1E-12); //Check Q orthogonal
         }
 
+
+     SECTION("Positive Real case rank deficient")
+        {
+	auto M = randomMat(P, N);
+	auto Id = eye(P, P);
+
+        Matrix Q, R;
+        QR(M,Q,R, {"Complete", true, "PositiveDiagonal", true});
+
+        auto T = Q*R;
+	auto QQ = Q*transpose(Q);
+
+        for(auto r : range(P))
+        for(auto c : range(N))
+            {
+            CHECK_CLOSE(T(r,c),M(r,c));
+	    if (r > c)
+	      CHECK(R(r,c) == 0); //Check R upper triangular
+	     if (r == c)
+	      CHECK(R(r,r) >= 0); //Check R upper triangular
+            }
+        CHECK(norm(T-M) < 1E-12*norm(M));
+	CHECK(norm(QQ-Id) <1E-12); //Check Q orthogonal
+        }
+
     SECTION("Real case thin")
         {
 	auto M = randomMat(N, P);
 	auto Id = eye(P, P);
 
         Matrix Q, R;
-        QR(M,Q,R, false);
+        QR(M,Q,R, {"Complete", false});
 
         auto T = Q*R;
 	auto QQ = transpose(Q)*Q;
@@ -1488,7 +1513,7 @@ SECTION("diagHermitian")
 	auto M = randomMatC(N, P);
 
         CMatrix Q, R;
-        QR(M,Q,R, true);
+        QR(M,Q,R, {"Complete", true});
 
         auto T = Q*R;
 	auto QQ = Q*conj(transpose(Q));
@@ -1511,7 +1536,7 @@ SECTION("diagHermitian")
         {
         auto M = randomMatC(P, N);
         CMatrix Q, R;
-        QR(M,Q,R, true);
+        QR(M,Q,R, {"Complete", true});
 
         auto T = Q*R;
 	auto QQ = Q*conj(transpose(Q));
@@ -1534,7 +1559,7 @@ SECTION("diagHermitian")
 	auto M = randomMatC(N, P);
 
         CMatrix Q, R;
-        QR(M,Q,R, false);
+        QR(M,Q,R, {"Complete", false});
 
         auto T = Q*R;
 	auto QQ = conj(transpose(Q))*Q;


### PR DESCRIPTION
Fixes #319 .

As I was interested and I implemented the QR I thought I might as well have a first attempt at this. Replaces orthog with QR in the ITensor SVD implementation and adds a "PositiveDiagonal" argument to QR to force the diagonal of R to be positive, as @emstoudenmire found to be necessary.

Currently passes the unit tests and very initial benchmarking (the orange line in graphs below -- I'll run the code for better averaging and dimension when I have time) suggests it runs faster and more accurately than before, but obviously should be looked over closely before merging by someone who understands the algorithm properly!

![image](https://user-images.githubusercontent.com/26630266/75599952-a501b680-5a5e-11ea-9012-6d9af8a134ce.png)

![image](https://user-images.githubusercontent.com/26630266/75599986-e003ea00-5a5e-11ea-9417-3e91b67a8ded.png)