### PR TITLE
Store block-offset list as an std::unordered_map

### DIFF
--- a/itensor/decomp.cc
+++ b/itensor/decomp.cc
@@ -95,11 +95,11 @@ doTask(GetBlocks<T> const& G,
     for(auto const& dio : d.offsets)
         {
         auto& R = res[n++];
-        auto nrow = G.is[0].blocksize0(dio.block[0]);
-        auto ncol = G.is[1].blocksize0(dio.block[1]);
-        R.i1 = dio.block[0];
-        R.i2 = dio.block[1];
-        R.M = makeMatRef(d.data()+dio.offset,d.size()-dio.offset,nrow,ncol);
+        auto nrow = G.is[0].blocksize0(dio.first[0]);
+        auto ncol = G.is[1].blocksize0(dio.first[1]);
+        R.i1 = dio.first[0];
+        R.i2 = dio.first[1];
+        R.M = makeMatRef(d.data()+dio.second,d.size()-dio.second,nrow,ncol);
         }
     if(G.transpose) 
         {

--- a/itensor/itdata/qdense.h
+++ b/itensor/itdata/qdense.h
@@ -238,8 +238,7 @@ template<typename T>
 void
 write(std::ostream & s, QDense<T> const& dat)
     {
-    //TODO: add writing BlockOffsets
-    //itensor::write(s,dat.offsets);
+    itensor::write(s,dat.offsets);
     itensor::write(s,dat.store);
     }
 
@@ -247,8 +246,7 @@ template<typename T>
 void
 read(std::istream & s, QDense<T> & dat)
     {
-    //TODO: add reading BlockOffsets
-    //itensor::read(s,dat.offsets);
+    itensor::read(s,dat.offsets);
     itensor::read(s,dat.store);
     }
 

--- a/itensor/itdata/qdense.h
+++ b/itensor/itdata/qdense.h
@@ -450,10 +450,6 @@ long
 offsetOf(BlockOffsets const& offsets,
          Block        const& blockind);
 
-int
-offsetOfLoc(BlockOffsets const& offsets,
-            Block        const& blockind);
-
 template<typename T>
 template<typename Indexable>
 std::tuple<T const*,Block,long> QDense<T>::

--- a/itensor/itdata/qdiag.cc
+++ b/itensor/itdata/qdiag.cc
@@ -607,15 +607,15 @@ doTask(ToDense & R,
     auto diag_block = true;
     for(auto i : range(1,ninds))
       {
-      if(io.block[i] != io.block[0])
+      if(io.first[i] != io.first[0])
         diag_block = false;
       }
 
     if(diag_block)
       {
       // Make a TenRef of the current block we want to assign to
-      dense_range.init(make_indexdim(R.is,io.block));
-      auto aref = makeTenRef(nd->data(),io.offset,nd->size(),&dense_range);
+      dense_range.init(make_indexdim(R.is,io.first));
+      auto aref = makeTenRef(nd->data(),io.second,nd->size(),&dense_range);
 
       long tot_stride = 0; //total strides for this block
       for(auto i : range(ninds))
@@ -632,7 +632,7 @@ doTask(ToDense & R,
         {
         // Get the diagonal elements of the current
         // block
-        auto pD = getBlock(d,R.is,io.block);
+        auto pD = getBlock(d,R.is,io.first);
         // Make a VecRef of the diagonal elements of the block to assign
         // to the diagonal of the new QDense storage block
         auto Dref = makeVecRef(pD.data(),pD.size());

--- a/itensor/itdata/qutil.h
+++ b/itensor/itdata/qutil.h
@@ -353,7 +353,8 @@ _loopContractedBlocksOMP(QDense<TA> const& A,
         auto ablock = getBlock(A,Ais,Ablockind);
         auto bblock = getBlock(B,Bis,Bblockind);
         auto cblock = getBlock(C,Cis,Cblockind);
-        auto Cblockloc = getBlockLoc(C,Cblockind);
+        //auto Cblockloc = getBlockLoc(C,Cblockind);
+        int Cblockloc = 0;
         callback(ablock,Ablockind,
                  bblock,Bblockind,
                  cblock,Cblockind,

--- a/itensor/itdata/qutil.h
+++ b/itensor/itdata/qutil.h
@@ -58,15 +58,6 @@ make_indexdim(IndexSet const& is, Indexable const& ind)
     return IndexDim<Indexable>(is,ind); 
     }
 
-template<typename T>
-int
-getBlockLoc(QDense<T> const& d,
-            Block const& block_ind)
-    {
-    auto loc = offsetOfLoc(d.offsets,block_ind);
-    return loc;
-    }
-
 template<typename BlockSparse>
 auto
 getBlock(BlockSparse & d,
@@ -274,11 +265,9 @@ _loopContractedBlocks(QDense<TA> const& A,
         auto ablock = getBlock(A,Ais,Ablockind);
         auto bblock = getBlock(B,Bis,Bblockind);
         auto cblock = getBlock(C,Cis,Cblockind);
-        auto Cblockloc = getBlockLoc(C,Cblockind);
         callback(ablock,Ablockind,
                  bblock,Bblockind,
-                 cblock,Cblockind,
-                 Cblockloc);
+                 cblock,Cblockind);
         }
     }
 
@@ -353,12 +342,9 @@ _loopContractedBlocksOMP(QDense<TA> const& A,
         auto ablock = getBlock(A,Ais,Ablockind);
         auto bblock = getBlock(B,Bis,Bblockind);
         auto cblock = getBlock(C,Cis,Cblockind);
-        //auto Cblockloc = getBlockLoc(C,Cblockind);
-        int Cblockloc = 0;
         callback(ablock,Ablockind,
                  bblock,Bblockind,
-                 cblock,Cblockind,
-                 Cblockloc);
+                 cblock,Cblockind);
         }
       }
     }

--- a/itensor/itdata/qutil.h
+++ b/itensor/itdata/qutil.h
@@ -413,7 +413,7 @@ _loopContractedBlocksOMPSingleOutputBlock(QDense<TA> const& A,
     auto cblock_size = cblock_tot.size();
     auto cblocks = std::vector<std::vector<TC>>(ncontractions);
 
-#pragma omp for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic)
     for(decltype(ncontractions) i = 0; i < ncontractions; i++)
         {
         auto const& [Ablockind,Bblockind,Cblockind] = blockContractions[i];

--- a/itensor/tensor/types.h
+++ b/itensor/tensor/types.h
@@ -18,6 +18,7 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <unordered_map>
 #include "itensor/util/infarray.h"
 #include "itensor/util/vararray.h"
 #include "itensor/util/vector_no_init.h"
@@ -238,14 +239,26 @@ operator<(Block const& l1, Block const& l2);
 bool
 operator>(Block const& l1, Block const& l2);
 
-struct BlOf
+// Borrowed from:
+// https://stackoverflow.com/questions/20511347/a-good-hash-function-for-a-vector
+class block_hasher
     {
-    Block block;
-    long offset;
+    public:
+
+    size_t
+    operator()(Block const& b) const
+        {
+        size_t seed = b.size();
+        for(auto& i : b)
+            seed ^= i + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
+        }
     };
 
+using BlOf = std::pair<Block,long>;
+
 using Blocks = std::vector<Block>;
-using BlockOffsets = std::vector<BlOf>;
+using BlockOffsets = std::unordered_map<Block,long,block_hasher>;
 
 BlOf
 make_blof(Block const& b, long o);

--- a/itensor/util/readwrite.h
+++ b/itensor/util/readwrite.h
@@ -309,15 +309,15 @@ write(std::ostream& s, const InfArray<T,N>& ia)
 void inline
 write(std::ostream & s, BlOf const& blof)
     {
-    itensor::write(s,blof.block);
-    itensor::write(s,blof.offset);
+    itensor::write(s,blof.first);
+    itensor::write(s,blof.second);
     }
 
 void inline
 read(std::istream & s, BlOf & blof)
     {
-    itensor::read(s,blof.block);
-    itensor::read(s,blof.offset);
+    itensor::read(s,blof.first);
+    itensor::read(s,blof.second);
     }
 
 //////////////////////////////////////////////

--- a/itensor/util/readwrite.h
+++ b/itensor/util/readwrite.h
@@ -220,6 +220,25 @@ write(std::ostream& s, std::vector<T,A> const& v)
         }
     }
 
+template<typename K, typename V, typename H>
+void
+read(std::istream& s, std::unordered_map<K,V,H> & umap)
+    {
+    auto v = std::vector<std::pair<K,V>>();
+    itensor::read(s,v);
+    umap.clear();
+    umap.insert(v.begin(),v.end());
+    }
+
+template<typename K, typename V, typename H>
+void
+write(std::ostream& s, std::unordered_map<K,V,H> const& umap)
+    {
+    auto size = umap.size();
+    itensor::write(s,size);
+    for(auto& el : umap) itensor::write(s,el);
+    }
+
 template<typename T, size_t N>
 auto
 read(std::istream& s, std::array<T,N> & a)


### PR DESCRIPTION
This PR implements a suggestion by Alex to use an std::unordered_map to store the block-offset list in the QDense storage instead of an std::vector. 

In profiles, we have seen the function `offsetOf` take up a significant amount of runtime (for example, around 10% for the 2D Hubbard model with momentum conservation around the cylinder). With std::vector storage, the offset of the block is determined by searching the sorted std::vector of pairs of blocks and offsets, and this search is what is taking up a lot of time. Using std::unordered_map, finding the offsets is an O(1) operation (at the expense of a higher memory overhead).

Here is a comparison for a 4x4 Hubbard model calculation with particle number, spin and momentum around the cylinder conserved. On v3 (with 12 OMP threads), we get:
```
    vN Entropy at center bond b=8 = 3.038161828684
    Eigs at center bond b=8: 0.1626 0.1609 0.1593 0.1591 0.0265 0.0258 0.0133 0.0131 0.0093 0.0093
    Largest link dim during sweep 5/5 was 9998
    Largest truncation error: 6.43277e-09
    Energy after sweep 5/5 is -18.867716016279
    Sweep 5/5 CPU time = 8m, 22.6s (Wall time = 1m, 6.9s)
```
while on this branch we get:
```
    vN Entropy at center bond b=8 = 3.038161829366
    Eigs at center bond b=8: 0.1626 0.1609 0.1593 0.1591 0.0265 0.0258 0.0133 0.0131 0.0093 0.0093
    Largest link dim during sweep 5/5 was 9998
    Largest truncation error: 6.43277e-09
    Energy after sweep 5/5 is -18.867716015839
    Sweep 5/5 CPU time = 12m, 0s (Wall time = 1m, 1.9s)
```
The speedup is not huge, but not insignificant (about 7.5%).

The main concern with this design is a possible increase in memory overhead. I did some heap profiling with gperftools of this example and did not see any noticeable difference. To me, this makes sense, since the memory overhead of this design would scale linearly in the number of blocks, so it should not be noticeable in the large bond dimension limit (where presumably you see block sizes growing faster than the number of blocks, and the memory scaling with the block sizes is square in the bond dimension for an MPS). So I think for memory limited calculations, I wouldn't expect this to have a significant change on what bond dimension can be reached. It is definitely something to keep in mind, though.