### PR TITLE
Random MPS for m > 1

### DIFF
--- a/itensor/detail/algs.h
+++ b/itensor/detail/algs.h
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <ctime>
 #include <stdexcept>
+#include <random>
 #include "itensor/types.h"
 
 namespace itensor {

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -224,28 +224,30 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
     auto N = length(s);
     auto M = MPS(N);
     auto l = vector<Index>(N+1);
-    int chi = dim(s(1));
+    int chi = dim(s(N));
     chi = std::min(m,chi);
-    l[1] = Index(chi,"Link,n=1");
-    auto O = randomOrthog(dim(s(1)),chi);
-    M.ref(1) = matrixITensor(O,s(1),l[1]);
-    for(int j : range1(2,N-1))
+    l[N-1] = Index(chi,format("Link,n=%d",N-1));
+    auto O = randomOrthog(chi,dim(s(N)));
+    M.ref(N) = matrixITensor(O,l[N-1],s(N));
+    for(int j = N-1; j > 1; j -= 1)
         {
         auto prev_chi = chi;
         chi *= dim(s(j));
         chi = std::min(m,chi);
-        l[j] = Index(chi,format("Link,n=%d",j));
-        O = randomOrthog(prev_chi*dim(s(j)),chi);
-        auto [C,c] = combiner(l[j-1],s(j));
-        M.ref(j) = matrixITensor(O,c,l[j]);
+        l[j-1] = Index(chi,format("Link,n=%d",j-1));
+        O = randomOrthog(chi,prev_chi*dim(s(j)));
+        auto [C,c] = combiner(s(j),l[j]);
+        M.ref(j) = matrixITensor(O,l[j-1],c);
         M.ref(j) *= C;
         }
-    O = randomOrthog(chi*dim(s(N)),1);
-    auto [C,c] = combiner(l[N-1],s(N));
-    l[N] = Index(1,"Link,n=N");
-    M.ref(N) = matrixITensor(O,c,l[N]);
-    M.ref(N) *= C;
-    M.ref(N) *= setElt(l[N](1));
+    O = randomOrthog(1,dim(s(1))*chi);
+    auto [C,c] = combiner(s(1),l[1]);
+    l[0] = Index(1,"Link,n=0");
+    M.ref(1) = matrixITensor(O,l[0],c);
+    M.ref(1) *= C;
+    M.ref(1) *= setElt(l[0](1));
+    M.leftLim(0);
+    M.rightLim(2);
     return M;
     }
 

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -227,7 +227,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
 
     //Make N'th MPS tensor
     int chi = dim(s(N));
-    l[N-1] = Index(chi,format("Link,n=%d",N-1));
+    l[N-1] = Index(chi,format("Link,l=%d",N-1));
     auto O = randomOrthog(chi,dim(s(N)));
     M.ref(N) = matrixITensor(O,l[N-1],s(N));
 
@@ -237,7 +237,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
         auto prev_chi = chi;
         chi *= dim(s(j));
         chi = std::min(m,chi);
-        l[j-1] = Index(chi,format("Link,n=%d",j-1));
+        l[j-1] = Index(chi,format("Link,l=%d",j-1));
         O = randomOrthog(chi,prev_chi*dim(s(j)));
         auto [C,c] = combiner(s(j),l[j]);
         M.ref(j) = matrixITensor(O,l[j-1],c);
@@ -247,7 +247,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
     //Make 1st MPS tensor
     O = randomOrthog(1,dim(s(1))*chi);
     auto [C,c] = combiner(s(1),l[1]);
-    l[0] = Index(1,"Link,n=0");
+    l[0] = Index(1,"Link,l=0");
     M.ref(1) = matrixITensor(O,l[0],c);
     M.ref(1) *= C;
     M.ref(1) *= setElt(l[0](1));

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -224,13 +224,16 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
     auto N = length(s);
     auto M = MPS(N);
     auto l = vector<Index>(N+1);
+
+    //Make N'th MPS tensor
     int chi = dim(s(N));
-    chi = std::min(m,chi);
     l[N-1] = Index(chi,format("Link,n=%d",N-1));
     auto O = randomOrthog(chi,dim(s(N)));
     M.ref(N) = matrixITensor(O,l[N-1],s(N));
+
     for(int j = N-1; j > 1; j -= 1)
         {
+        //Make j'th MPS tensor
         auto prev_chi = chi;
         chi *= dim(s(j));
         chi = std::min(m,chi);
@@ -240,12 +243,15 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
         M.ref(j) = matrixITensor(O,l[j-1],c);
         M.ref(j) *= C;
         }
+
+    //Make 1st MPS tensor
     O = randomOrthog(1,dim(s(1))*chi);
     auto [C,c] = combiner(s(1),l[1]);
     l[0] = Index(1,"Link,n=0");
     M.ref(1) = matrixITensor(O,l[0],c);
     M.ref(1) *= C;
     M.ref(1) *= setElt(l[0](1));
+
     M.leftLim(0);
     M.rightLim(2);
     return M;
@@ -254,21 +260,12 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
 MPS
 randomMPS(SiteSet const& sites, int m, Args const& args)
     {
-    if(not hasQNs(sites))
-        {
-        if(m == 1)
-            {
-            auto psi = MPS(sites,m);
-            psi.randomize(args);
-            return psi;
-            }
-        return randomCircuitMPS(sites,m,args);
-        }
-    else
-        {
-        Error("randomMPS(SiteSet) with QN conservation is ambiguous, use randomMPS(InitState) instead.");
-        }
-    return MPS();
+    if(hasQNs(sites))
+    {
+    Error("randomMPS(SiteSet) with QN conservation is ambiguous, use randomMPS(InitState) instead.");
+    }
+
+    return randomCircuitMPS(sites,m,args);
     }
 
 MPS

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -18,6 +18,7 @@
 #include "itensor/mps/localop.h"
 #include "itensor/util/print_macro.h"
 #include "itensor/util/str.h"
+#include "itensor/tensor/algs.h"
 
 namespace itensor {
 
@@ -196,6 +197,25 @@ int
 length(MPS const& W)
     {
     return W.length();
+    }
+
+Matrix
+randomOrthog(int n, int m)
+    {
+    auto r = std::max(n,m);
+    auto M = randn(r,r);
+    Matrix Q,R;
+    QR(M,Q,R,{"PositiveDiagonal",true});
+    if(m < n)
+        {
+        reduceCols(Q,m);
+        }
+    else if(n < m)
+        {
+        reduceCols(Q,n);
+        return Matrix(transpose(Q));
+        }
+    return Q;
     }
 
 MPS

--- a/itensor/tensor/mat.h
+++ b/itensor/tensor/mat.h
@@ -302,6 +302,20 @@ template<typename... CtrArgs>
 CMatrix
 randomMatC(CtrArgs&&... args);
 
+
+//
+// Generate a random matrix
+// with normally distributed
+// elements: M(i,j) ~ N(0,1)
+// 
+template<typename... CtrArgs>
+Matrix
+randn(CtrArgs&&... args);
+
+template<typename... CtrArgs>
+CMatrix
+randnC(CtrArgs&&... args);
+
 template<>
 std::ostream&
 operator<<(std::ostream& s, MatrixRefc const& M);

--- a/itensor/tensor/mat_impl.h
+++ b/itensor/tensor/mat_impl.h
@@ -182,6 +182,30 @@ randomMatC(CtrArgs&&... args)
     return M;
     }
 
+template<typename... CtrArgs>
+Matrix
+randn(CtrArgs&&... args)
+    {
+    auto M = Matrix(std::forward<CtrArgs>(args)...);
+    std::random_device rd{};
+    std::mt19937 gen{rd()};
+    std::normal_distribution<> normal{0,1};
+    for(auto& el : M) el = normal(gen);
+    return M;
+    }
+
+template<typename... CtrArgs>
+CMatrix
+randnC(CtrArgs&&... args)
+    {
+    auto M = CMatrix(std::forward<CtrArgs>(args)...);
+    std::random_device rd{};
+    std::mt19937 gen{rd()};
+    std::normal_distribution<> normal{0,1};
+    for(auto& el : M) el = std::complex(normal(gen),normal(gen));
+    return M;
+    }
+
 } //namespace itensor
 
 #endif


### PR DESCRIPTION
This PR implements a random MPS generating algorithm based on random unitaries which works for bond dimensions greater than 1, and creates MPS with typical properties, resembling ground states of gapped Hamiltonians. (Versus randomizing individual MPS tensors which leads to pathological properties such as very short-range correlators.)

Some to-do items for future work (not this PR):
- test this algorithm versus a TEBD like algorithm with a brick wall circuit
- implement versions of randomMPS for QN-conserving MPS