### PR TITLE
Fix excited-state DMRG bug

### DIFF
--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -1168,6 +1168,7 @@ daxpy(ITensor & L,
       Real alpha)
     {
     if(L.order() != R.order()) Error("ITensor::operator+=: different number of indices");
+    if(nnzblocks(R) == 0) return;
     detail::checkSameDiv(L,R);
 
     using permutation = typename PlusEQ::permutation;


### PR DESCRIPTION
This PR (hopefully) fixes a persistent bug with excited state DMRG. The issue found was that addition of QN ITensors was failing when one of the tensors had no blocks, in which case the QN flux was being reported as QN() and then triggering a check that the fluxes were the same.