### PR TITLE
A possible bugfix in nmultMPO

### DIFF
--- a/itensor/mps/mpoalgs.cc
+++ b/itensor/mps/mpoalgs.cc
@@ -57,7 +57,7 @@ nmultMPO(MPO const& Aorig,
         }
 
     auto lA = linkInds(A);
-    auto lB = linkInds(A);
+    auto lB = linkInds(B);
     auto sA = uniqueSiteInds(A,B);
     auto sB = uniqueSiteInds(B,A);
 
@@ -86,7 +86,6 @@ nmultMPO(MPO const& Aorig,
         if(i == N-1) break;
 
         nfork = ITensor(lA(i),lB(i),linkIndex(res,i));
-
         denmatDecomp(clust,res.ref(i),nfork,Fromleft,{args,"Tags=",tags(lA(i))});
 
         auto mid = commonIndex(res(i),nfork);


### PR DESCRIPTION
This is a possible bugfix in `nmultMPO`. It was brought up in the support forum (http://www.itensor.org/support/2024/possible-error-in-itensor-library-v3-mpoalgs-cc). It is a bit confusing because the old version looks wrong, but all tests of `nmultMPO` were passing. 

Perhaps we should wait to merge once we get an example of this fixing an error.