### PR TITLE
Remove util/print_macro.h from all.h

### DIFF
--- a/itensor/all_basic.h
+++ b/itensor/all_basic.h
@@ -32,7 +32,6 @@
 #include "itensor/iterativesolvers.h"
 #include "itensor/util/input.h"
 #include "itensor/util/autovector.h"
-#include "itensor/util/print_macro.h"
 #include "itensor/util/str.h"
 
 #endif

--- a/itensor/decomp.h
+++ b/itensor/decomp.h
@@ -15,7 +15,7 @@
 //
 #ifndef __ITENSOR_DECOMP_H
 #define __ITENSOR_DECOMP_H
-#include "itensor/util/print_macro.h"
+//#include "itensor/util/print_macro.h"
 #include "itensor/spectrum.h"
 #include "itensor/itensor.h"
 

--- a/itensor/mps/localmpo.h
+++ b/itensor/mps/localmpo.h
@@ -17,7 +17,7 @@
 #define __ITENSOR_LOCALMPO
 #include "itensor/mps/mpo.h"
 #include "itensor/mps/localop.h"
-#include "itensor/util/print_macro.h"
+//#include "itensor/util/print_macro.h"
 
 namespace itensor {
 

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -73,4 +73,4 @@ mkdebugdir:
 clean:
 	@rm -fr *.o .debug_objs dmrg dmrg-g \
 	dmrg_table dmrg_table-g dmrgj1j2 dmrgj1j2-g exthubbard exthubbard-g \
-    mixedspin mixedspin-g trg trg-g
+    mixedspin mixedspin-g trg trg-g hubbard_2d hubbard_2d-g

--- a/sample/exthubbard.cc
+++ b/sample/exthubbard.cc
@@ -1,4 +1,5 @@
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/sample/trg.cc
+++ b/sample/trg.cc
@@ -1,4 +1,5 @@
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/tutorial/01_one_site/one.cc
+++ b/tutorial/01_one_site/one.cc
@@ -3,6 +3,7 @@
 // ITensor Tutorial
 //
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/tutorial/02_two_site/two.cc
+++ b/tutorial/02_two_site/two.cc
@@ -3,6 +3,7 @@
 // ITensor Tutorial
 //
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/tutorial/03_svd/svd.cc
+++ b/tutorial/03_svd/svd.cc
@@ -3,6 +3,7 @@
 // ITensor Tutorial
 //
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/tutorial/04_mps/mps.cc
+++ b/tutorial/04_mps/mps.cc
@@ -3,6 +3,7 @@
 // ITensor Tutorial
 //
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 using std::vector;

--- a/tutorial/05_gates/gates.cc
+++ b/tutorial/05_gates/gates.cc
@@ -3,6 +3,7 @@
 // ITensor Tutorial
 //
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using std::vector;
 using std::move;

--- a/tutorial/06_DMRG/dmrg.cc
+++ b/tutorial/06_DMRG/dmrg.cc
@@ -3,6 +3,7 @@
 // ITensor Tutorial
 //
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/tutorial/finiteT/ancilla.cc
+++ b/tutorial/finiteT/ancilla.cc
@@ -1,6 +1,7 @@
 #include "itensor/all.h"
 #include "TStateObserver.h"
 #include "S2.h"
+#include "itensor/util/print_macro.h"
 
 using namespace std;
 using namespace itensor;

--- a/tutorial/finiteT/metts.cc
+++ b/tutorial/finiteT/metts.cc
@@ -1,5 +1,6 @@
 #include "itensor/all.h"
 #include "S2.h"
+#include "itensor/util/print_macro.h"
 
 using namespace std;
 using namespace itensor;

--- a/tutorial/finiteT/metts_solution.cc
+++ b/tutorial/finiteT/metts_solution.cc
@@ -1,5 +1,6 @@
 #include "itensor/all.h"
 #include "S2.h"
+#include "itensor/util/print_macro.h"
 
 using namespace std;
 using namespace itensor;


### PR DESCRIPTION
This PR fixes bug #279, which is that the itensor/all.h convenience header pulls in util/print_macro.h. However, this can cause conflicts with other libraries which may use the name Print for variables, function names, or other macros. To use the Print macro going forward, users must include itensor/util/print_macro.h explicitly.

Fixes #279