### PR TITLE
fixed unwanted range behavior if start > end

### DIFF
--- a/itensor/util/iterate.h
+++ b/itensor/util/iterate.h
@@ -54,7 +54,7 @@ class RangeHelper
     bool
     operator!=(RangeHelper const& other) const
         {
-        return curr_ != other.curr_;
+        return curr_ < other.curr_;
         }
 
     RangeHelper 


### PR DESCRIPTION
Changed the != operator in RangeHelper:
Instead of "!=" use "<" to account for cases where curr_ > end_ from initialization.

Tested the changes so they fix the bug and still give the same output in the other cases.