### PR TITLE
Update lapack wrapper functions to use LAPACK_INT

### DIFF
--- a/itensor/tensor/algs.cc
+++ b/itensor/tensor/algs.cc
@@ -34,45 +34,49 @@ namespace detail {
     int
     hermitianDiag(int N, Real *Udata, Real *ddata)
         {
+        LAPACK_INT _N = N;
         LAPACK_INT info = 0;
-        dsyev_wrapper('V','U',N,Udata,ddata,info);
+        dsyev_wrapper('V','U',_N,Udata,ddata,info);
         return info;
         }
     int
     hermitianDiag(int N, Cplx *Udata,Real *ddata)
         {
-        return zheev_wrapper(N,Udata,ddata);
+        LAPACK_INT _N = N;
+        return zheev_wrapper(_N,Udata,ddata);
         }
 
     int
     QR(int M, int N, int Rrows, Real *Qdata, Real *Rdata)
         {
+        LAPACK_INT _M = M, _N = N, _Rrows = Rrows;
         LAPACK_INT info = 0;
-        std::vector<LAPACK_REAL> tau(N);
-        dgeqrf_wrapper(&M, &N, Qdata, &M, tau.data(), &info);
-        for(int i = 0; i < Rrows; i++)
-        for(int j = i; j < N; j++) 
+        std::vector<LAPACK_REAL> tau(_N);
+        dgeqrf_wrapper(&_M, &_N, Qdata, &_M, tau.data(), &info);
+        for(LAPACK_INT i = 0; i < _Rrows; i++)
+        for(LAPACK_INT j = i; j < _N; j++) 
             {
-            Rdata[i + j*Rrows] = Qdata[i+j*M];
+            Rdata[i + j*_Rrows] = Qdata[i+j*_M];
             }
-        int min = M < N ? M : N;
-        dorgqr_wrapper(&M, &Rrows, &min, Qdata, &M, tau.data(), &info);
+        LAPACK_INT min = _M < _N ? _M : _N;
+        dorgqr_wrapper(&_M, &_Rrows, &min, Qdata, &_M, tau.data(), &info);
         return info;
         }
 
     int
     QR(int M, int N, int Rrows, Cplx *Qdata, Cplx *Rdata)
         {
+        LAPACK_INT _M = M, _N = N, _Rrows = Rrows;
         LAPACK_INT info = 0;
         std::vector<LAPACK_COMPLEX> tau(N);
-        zgeqrf_wrapper(&M, &N, Qdata, &M, tau.data(), &info);
-        for(int i = 0; i < Rrows; i++)
-        for(int j = i; j < N; j++) 
+        zgeqrf_wrapper(&_M, &_N, Qdata, &_M, tau.data(), &info);
+        for(LAPACK_INT i = 0; i < _Rrows; i++)
+        for(LAPACK_INT j = i; j < _N; j++) 
             {
-            Rdata[i + j*Rrows] = Qdata[i+j*M];
+            Rdata[i + j*_Rrows] = Qdata[i+j*_M];
             }
-        int min = M < N ? M : N;
-        zungqr_wrapper(&M, &Rrows, &min, Qdata, &M, tau.data(), &info);
+        LAPACK_INT min = _M < _N ? _M : _N;
+        zungqr_wrapper(&_M, &_Rrows, &min, Qdata, &_M, tau.data(), &info);
         return info;
         }
 
@@ -80,18 +84,20 @@ namespace detail {
   int
   SVD_gesdd(int M, int N, Cplx * Adata, Cplx * Udata, Real * Ddata, Cplx * Vdata)
     {
+    LAPACK_INT _M = M, _N = N;
     LAPACK_INT info = 0;
     char S = 'S';
-    zgesdd_wrapper(&S, &M, &N, Adata, Ddata,  Udata, Vdata, &info);
+    zgesdd_wrapper(&S, &_M, &_N, Adata, Ddata,  Udata, Vdata, &info);
     return info;
     }
 
     int
     SVD_gesdd(int M, int N, Real * Adata, Real * Udata, Real * Ddata, Real * Vdata)
     {
+    LAPACK_INT _M = M, _N = N;
     LAPACK_INT info = 0;
     char S = 'S';
-    dgesdd_wrapper(&S, &M, &N, Adata, Ddata,  Udata, Vdata, &info);
+    dgesdd_wrapper(&S, &_M, &_N, Adata, Ddata,  Udata, Vdata, &info);
     return info;
     }
 
@@ -99,18 +105,20 @@ namespace detail {
     int
     SVD_gesvd(int M, int N, Cplx * Adata, Cplx * Udata, Real * Ddata, Cplx * Vdata)
         {
+        LAPACK_INT _M = M, _N = N;
         LAPACK_INT info = 0;
         char S = 'S';
-        zgesvd_wrapper(&S, &M, &N, Adata, Ddata,  Udata, Vdata, &info);
+        zgesvd_wrapper(&S, &_M, &_N, Adata, Ddata,  Udata, Vdata, &info);
         return info;
         }
 
     int
     SVD_gesvd(int M, int N, Real * Adata, Real * Udata, Real * Ddata, Real * Vdata)
         {
+        LAPACK_INT _M = M, _N = N;
         LAPACK_INT info = 0;
         char S = 'S';
-        dgesvd_wrapper(&S, &M, &N, Adata, Ddata,  Udata, Vdata, &info);
+        dgesvd_wrapper(&S, &_M, &_N, Adata, Ddata,  Udata, Vdata, &info);
         return info;
         }
 

--- a/itensor/tensor/lapack_wrap.cc
+++ b/itensor/tensor/lapack_wrap.cc
@@ -327,11 +327,12 @@ dsyev_wrapper(char jobz,        //if jobz=='V', compute eigs and evecs
               LAPACK_REAL* eigs, //eigenvalues on return
               LAPACK_INT& info)  //error info
     {
+    static const LAPACK_INT one = 1;
     std::vector<LAPACK_REAL> work;
     LAPACK_INT lda = n;
 
 #ifdef PLATFORM_acml
-    LAPACK_INT lwork = std::max(1,3*n-1);
+    LAPACK_INT lwork = std::max(one,3*n-1);
     work.resize(lwork+2);
     F77NAME(dsyev)(&jobz,&uplo,&n,A,&lda,eigs,work.data(),&lwork,&info,1,1);
 #else
@@ -499,8 +500,9 @@ dgeqrf_wrapper(LAPACK_INT* m,     //number of rows of A
                                   //length should be min(m,n)
                LAPACK_INT* info)  //error info
     {
+    static const LAPACK_INT one = 1;
     std::vector<LAPACK_REAL> work;
-    int lwork = std::max(1,4*std::max(*n,*m));
+    LAPACK_INT lwork = std::max(one,4*std::max(*n,*m));
     work.resize(lwork+2); 
     F77NAME(dgeqrf)(m,n,A,lda,tau,work.data(),&lwork,info);
     }
@@ -520,8 +522,9 @@ dorgqr_wrapper(LAPACK_INT* m,     //number of rows of A
                LAPACK_REAL* tau,  //scalar factors as returned by dgeqrf
                LAPACK_INT* info)  //error info
     {
+    static const LAPACK_INT one = 1;
     std::vector<LAPACK_REAL> work;
-    auto lwork = std::max(1,4*std::max(*n,*m));
+    auto lwork = std::max(one,4*std::max(*n,*m));
     work.resize(lwork+2); 
     F77NAME(dorgqr)(m,n,k,A,lda,tau,work.data(),&lwork,info);
     }
@@ -542,8 +545,9 @@ zgeqrf_wrapper(LAPACK_INT* m,     //number of rows of A
                                   //length should be min(m,n)
                LAPACK_INT* info)  //error info
     {
+    static const LAPACK_INT one = 1;
     std::vector<LAPACK_COMPLEX> work;
-    int lwork = std::max(1,4*std::max(*n,*m));
+    LAPACK_INT lwork = std::max(one,4*std::max(*n,*m));
     work.resize(lwork+2);
     static_assert(sizeof(LAPACK_COMPLEX)==sizeof(Cplx),"LAPACK_COMPLEX and itensor::Cplx have different size");
     auto pA = reinterpret_cast<LAPACK_COMPLEX*>(A);
@@ -565,8 +569,9 @@ zungqr_wrapper(LAPACK_INT* m,     //number of rows of A
                LAPACK_COMPLEX* tau,  //scalar factors as returned by dgeqrf
                LAPACK_INT* info)  //error info
     {
+    static const LAPACK_INT one = 1;
     std::vector<LAPACK_COMPLEX> work;
-    auto lwork = std::max(1,4*std::max(*n,*m));
+    auto lwork = std::max(one,4*std::max(*n,*m));
     work.resize(lwork+2);
     static_assert(sizeof(LAPACK_COMPLEX)==sizeof(Cplx),"LAPACK_COMPLEX and itensor::Cplx have different size");
     auto pA = reinterpret_cast<LAPACK_COMPLEX*>(A);
@@ -675,13 +680,14 @@ zheev_wrapper(LAPACK_INT      N,  //number of cols of A
               Cplx          * A,  //matrix A, on return contains eigenvectors
               LAPACK_REAL   * d)  //eigenvalues on return
     {
+    static const LAPACK_INT one = 1;
     char jobz = 'V';
     char uplo = 'U';
 #ifdef PLATFORM_lapacke
     std::vector<LAPACK_REAL> work(N);
     LAPACKE_zheev(LAPACK_COL_MAJOR,jobz,uplo,N,A,N,w.data());
 #else
-    LAPACK_INT lwork = std::max(1,3*N-1);//max(1, 1+6*N+2*N*N);
+    LAPACK_INT lwork = std::max(one,3*N-1);//max(1, 1+6*N+2*N*N);
     std::vector<LAPACK_COMPLEX> work(lwork);
     std::vector<LAPACK_REAL> rwork(lwork);
     LAPACK_INT info = 0;
@@ -717,9 +723,10 @@ dsygv_wrapper(char* jobz,           //if 'V', compute both eigs and evecs
               LAPACK_REAL* d,       //eigenvalues on return
               LAPACK_INT* info)  //error info
     {
+    static const LAPACK_INT one = 1;
     std::vector<LAPACK_REAL> work;
-    int itype = 1;
-    LAPACK_INT lwork = std::max(1,3*(*n)-1);//std::max(1, 1+6*N+2*N*N);
+    LAPACK_INT itype = 1;
+    LAPACK_INT lwork = std::max(one,3*(*n)-1);//std::max(1, 1+6*N+2*N*N);
     work.resize(lwork);
 #ifdef PLATFORM_acml
     LAPACK_INT jobz_len = 1;
@@ -804,14 +811,15 @@ zgeev_wrapper(char jobvl,          //if 'V', compute left eigenvectors, else 'N'
               Cplx * vl,   //left eigenvectors on return
               Cplx * vr)   //right eigenvectors on return
     {
+    static const LAPACK_INT one = 1;
     std::vector<LAPACK_COMPLEX> cpA;
     std::vector<LAPACK_COMPLEX> work;
     std::vector<LAPACK_REAL> rwork;
-    int nevecl = (jobvl == 'V' ? n : 1);
-    int nevecr = (jobvr == 'V' ? n : 1);
-    LAPACK_INT lwork = std::max(1,4*n);
+    LAPACK_INT nevecl = (jobvl == 'V' ? n : 1);
+    LAPACK_INT nevecr = (jobvr == 'V' ? n : 1);
+    LAPACK_INT lwork = std::max(one,4*n);
     work.resize(lwork);
-    LAPACK_INT lrwork = std::max(1,2*n);
+    LAPACK_INT lrwork = std::max(one,2*n);
     rwork.resize(lrwork);
 
     //Copy A data into cpA


### PR DESCRIPTION
`int` is used here and there in functions inside `lapack_wrap.cc` and `algs.cc`.
Replace them with `LAPACK_INT` so that ITensor can be linked to BLAS/LAPACK with ILP64.