### PR TITLE
Remove unnecessary #include from global.h

### DIFF
--- a/itensor/global.h
+++ b/itensor/global.h
@@ -21,7 +21,6 @@
 #include <cstring>
 #include <memory>
 #include <random>
-#include <unistd.h>
 #include <memory>
 #include "itensor/util/iterate.h"
 #include "itensor/util/error.h"


### PR DESCRIPTION
`unistd.h` is not used within `global.h`