### PR TITLE
Restore mixed fermionic and non-fermionic AutoMPO support

### DIFF
--- a/itensor/Makefile
+++ b/itensor/Makefile
@@ -184,7 +184,7 @@ svd.o: $(ITDEPHEADERS) $(GDEPHEADERS)
 .debug_objs/svd.o: $(ITDEPHEADERS) $(GDEPHEADERS)
 hermitian.o: $(ITDEPHEADERS) $(GDEPHEADERS)
 .debug_objs/hermitian.o: $(ITDEPHEADERS) $(GDEPHEADERS)
-GDEPHEADERS+= mps/mps.h
+GDEPHEADERS+= mps/mps.h mps/siteset.h
 mps/mps.o: $(ITDEPHEADERS) $(GDEPHEADERS)
 .debug_objs/mps/mps.o: $(ITDEPHEADERS) $(GDEPHEADERS)
 mps/mpsalgs.o: $(ITDEPHEADERS) $(GDEPHEADERS)

--- a/itensor/mps/sites/Z3.h
+++ b/itensor/mps/sites/Z3.h
@@ -61,7 +61,7 @@ class Z3Site
         if(state == "2") { return s(3); }
         else
             {
-            Error("State " + state + " not recognized");
+            throw ITError("State " + state + " not recognized");
             }
         return IndexVal{};
         }
@@ -131,7 +131,7 @@ class Z3Site
             }
         else
             {
-            Error("Operator \"" + opname + "\" name not recognized");
+            throw ITError("Operator \"" + opname + "\" name not recognized");
             }
 
         return Op;

--- a/itensor/mps/sites/boson.h
+++ b/itensor/mps/sites/boson.h
@@ -63,7 +63,7 @@ class BosonSite
             }
         else
             {
-            if(conserveNb) Error("ConserveNb cannot be true when ConserveQNs=false");
+            if(conserveNb) throw ITError("ConserveNb cannot be true when ConserveQNs=false");
             s = Index(1+maxOcc,tags);
             }
         }
@@ -80,7 +80,7 @@ class BosonSite
             if(state == str(n)) return s(1+n);
             }
 	if(state == "Emp")return s(1);
-        Error("State " + state + " not recognized");
+        throw ITError("State " + state + " not recognized");
         return IndexVal{};
         }
 
@@ -118,7 +118,7 @@ class BosonSite
             }
         else
             {
-            Error("Operator \"" + opname + "\" name not recognized");
+            throw ITError("Operator \"" + opname + "\" name not recognized");
             }
 
         return Op;

--- a/itensor/mps/sites/customspin.h
+++ b/itensor/mps/sites/customspin.h
@@ -68,7 +68,7 @@ class CustomSpinSite
             }
         else
             {
-            if(conserveSz) Error("ConserveSz cannot be true when ConserveQNs=false");
+            if(conserveSz) throw ITError("ConserveSz cannot be true when ConserveQNs=false");
             s = Index(DSmax+1,tags);
             }
         }
@@ -85,7 +85,7 @@ class CustomSpinSite
             {
             if(state == str(2*n-DSmax)) return s(1+n); //state name is "2Sz"
             }
-        Error("State " + state + " not recognized");
+        throw ITError("State " + state + " not recognized");
         return IndexVal{};
         }
 
@@ -153,7 +153,7 @@ class CustomSpinSite
             }
         else
             {
-            Error("Operator " + opname + " name not recognized");
+            throw ITError("Operator " + opname + " name not recognized");
             }
 
         return Op;

--- a/itensor/mps/sites/electron.h
+++ b/itensor/mps/sites/electron.h
@@ -105,7 +105,7 @@ class ElectronSite
             }
         else
             {
-            Error("State " + state + " not recognized");
+            throw ITError("State " + state + " not recognized");
             }
         return IndexVal{};
         }
@@ -247,7 +247,7 @@ class ElectronSite
             }
         else
             {
-            Error("Operator \"" + opname + "\" name not recognized");
+            throw ITError("Operator \"" + opname + "\" name not recognized");
             }
 
         return Op;

--- a/itensor/mps/sites/fermion.h
+++ b/itensor/mps/sites/fermion.h
@@ -88,7 +88,7 @@ class FermionSite
             }
         else
             {
-            Error("State " + state + " not recognized");
+            throw ITError("State " + state + " not recognized");
             }
         return IndexVal{};
         }
@@ -148,7 +148,7 @@ class FermionSite
             }
         else
             {
-            Error("Operator \"" + opname + "\" name not recognized");
+            throw ITError("Operator \"" + opname + "\" name not recognized");
             }
 
         return Op;

--- a/itensor/mps/sites/spinhalf.h
+++ b/itensor/mps/sites/spinhalf.h
@@ -77,7 +77,7 @@ class SpinHalfSite
             }
         else
             {
-            Error("State " + state + " not recognized");
+            throw ITError("State " + state + " not recognized");
             }
         return IndexVal{};
         }
@@ -110,7 +110,7 @@ class SpinHalfSite
             //    }
             //else
             //    {
-            //    Error("Operator " + opname + " does not have a well defined QN flux");
+            //    throw ITError("Operator " + opname + " does not have a well defined QN flux");
             //    }
             }
         else
@@ -123,7 +123,7 @@ class SpinHalfSite
             //    }
             //else
             //    {
-            //    Error("Operator " + opname + " does not have a well defined QN flux");
+            //    throw ITError("Operator " + opname + " does not have a well defined QN flux");
             //    }
             }
         else
@@ -136,7 +136,7 @@ class SpinHalfSite
             //    }
             //else
             //    {
-            //    Error("Operator " + opname + " does not have a well defined QN flux");
+            //    throw ITError("Operator " + opname + " does not have a well defined QN flux");
             //    }
             }
         else
@@ -167,7 +167,7 @@ class SpinHalfSite
             }
         else
             {
-            Error("Operator \"" + opname + "\" name not recognized");
+            throw ITError("Operator \"" + opname + "\" name not recognized");
             }
 
         return Op;

--- a/itensor/mps/sites/spinone.h
+++ b/itensor/mps/sites/spinone.h
@@ -86,7 +86,7 @@ class SpinOneSite
             }
         else
             {
-            Error("State " + state + " not recognized");
+            throw ITError("State " + state + " not recognized");
             }
         return IndexVal{};
         }
@@ -223,7 +223,7 @@ class SpinOneSite
             }
         else
             {
-            Error("Operator \"" + opname + "\" name not recognized");
+            throw ITError("Operator \"" + opname + "\" name not recognized");
             }
 
         return Op;
@@ -251,7 +251,7 @@ SpinOne(std::vector<Index> const& inds)
         if(dim(Ii) != 3)
             {
             printfln("Index at entry %d = %s",i,Ii);
-            Error("Only S=1 IQIndices allowed in SpinOne(vector<Index>) constructor");
+            throw ITError("Only S=1 IQIndices allowed in SpinOne(vector<Index>) constructor");
             }
         sites.set(j,SpinOneSite(Ii));
         }
@@ -306,7 +306,7 @@ read(std::istream& s)
             I.read(s);
             if(dim(I) == 3) store.set(j,SpinOneSite(I));
             else if(dim(I) == 2) store.set(j,SpinHalfSite(I));
-            else Error(format("SpinOne cannot read index of size %d",dim(I)));
+            else throw ITError(format("SpinOne cannot read index of size %d",dim(I)));
             }
         init(std::move(store));
         }

--- a/itensor/mps/sites/spintwo.h
+++ b/itensor/mps/sites/spintwo.h
@@ -94,7 +94,7 @@ class SpinTwoSite
             }
         else
             {
-            Error("State " + state + " not recognized");
+            throw ITError("State " + state + " not recognized");
             }
         return IndexVal{};
 		}
@@ -240,7 +240,7 @@ class SpinTwoSite
             }
         else
             {
-            Error("Operator " + opname + " name not recognized");
+            throw ITError("Operator " + opname + " name not recognized");
             }
 
         return Op;
@@ -305,7 +305,7 @@ read(std::istream& s)
             I.read(s);
             if(dim(I) == 5) store.set(j,SpinTwoSite(I));
             else if(dim(I) == 2) store.set(j,SpinHalfSite(I));
-            else Error(format("SpinTwo cannot read index of size %d",dim(I)));
+            else throw ITError(format("SpinTwo cannot read index of size %d",dim(I)));
             }
         init(std::move(store));
         }

--- a/itensor/mps/sites/tj.h
+++ b/itensor/mps/sites/tj.h
@@ -94,7 +94,7 @@ class tJSite
             }
         else
             {
-            Error("State " + state + " not recognized");
+            throw ITError("State " + state + " not recognized");
             }
         return IndexVal();
         }
@@ -214,7 +214,7 @@ class tJSite
             }
         else
             {
-            Error("Operator \"" + opname + "\" name not recognized");
+            throw ITError("Operator \"" + opname + "\" name not recognized");
             }
 
         return Op;

--- a/itensor/mps/siteset.h
+++ b/itensor/mps/siteset.h
@@ -380,6 +380,22 @@ op(String const& opname,
         return setElt(dag(v),prime(v));
         }
     else
+    if(opname == "F")
+        {
+        try {
+            return sites_->op(i,opname,args);
+        } catch(...) {
+            //
+            // If no "F" operator defined by site set
+            // then return a 'trivial' F operator
+            // equal to the identity:
+            auto s = si(i);
+            auto trivF = ITensor(dag(s),prime(s));
+            for(auto j : range1(dim(s))) trivF.set(j,j,1.0);
+            return trivF;
+        }
+        }
+    else
         {
         auto op1 = [](std::string const& opname, size_t n)
             {

--- a/unittest/autompo_test.cc
+++ b/unittest/autompo_test.cc
@@ -474,7 +474,6 @@ SECTION("Electron with no QNs")
     auto t0 = 5.0;
 
     auto sites = Fermion(N, {"ConserveQNs=",false});
-    Print(sites(1));
 
     auto ampo = AutoMPO(sites);
 
@@ -630,6 +629,30 @@ SECTION("Fermion")
         CHECK_CLOSE(inner(lpsi2,Hx,lpsi1),-t);
         CHECK_CLOSE(inner(lpsi2,Ha,lpsi1),-t);
         }
+    }
+
+SECTION("Mixed Fermion and Non-Fermion Sites")
+    {
+    // This test checks whether fermionic and non-fermionic
+    // sites can be successfully mixed together and used
+    // in the AutoMPO system. One possible issue is whether
+    // the Jordan-Wigner "F" operator is defined for
+    // non-fermionic sites
+    using FSpin = MixedSiteSet<FermionSite,SpinHalfSite>;
+    int N = 6;
+    auto t = 1.0;
+
+    auto sites = FSpin(N);
+
+    auto ampo = AutoMPO(sites);
+    for(int j = 1; j < N-1; j += 2)
+        {
+        ampo += -t,"Cdag",j,"C",j+2;
+        ampo += -t,"Cdag",j+2,"C",j;
+        }
+
+    MPO H;
+    CHECK_NOTHROW(H = toMPO(ampo));
     }
 
 }


### PR DESCRIPTION
This PR restores a capability accidentally removed by PR #373.
That PR fixes an issue with the default definition of the "F"
operator where it only worked for cases with QNs. This PR
keeps that fix but restores a default, fall-back definition
of "F" for site types which do not define that operator, allowing
them to be mixed with fermionic site types.

- Create test for mixing fermionic and non-fermionic sites
- Add siteset.h dependency
- Change error handling in site sets to throw exceptions
- Restore default "F" but try to use custom one now
