### PR TITLE
Remove the make warnings on comparing size_t and int values

### DIFF
--- a/itensor/tensor/mat.cc
+++ b/itensor/tensor/mat.cc
@@ -98,8 +98,8 @@ multReal(MatRef<V> const& M, Real fac)
     if(isContiguous(M))
         {
 #ifdef DEBUG
-        if(M.size() > std::numeric_limits<LAPACK_INT>::max()) 
-            throw std::runtime_error("MatrixRef overflow of size beyond LAPACK_INT range");
+        if(M.size() > std::numeric_limits<unsigned long>::max()) 
+            throw std::runtime_error("MatrixRef overflow of size beyond long unsigned int range");
 #endif
         auto d = realData(M);
         dscal_wrapper(d.size(),fac,d.data());
@@ -174,8 +174,8 @@ call_daxpy(MatT1& A, MatT2 const& B, Real alpha_)
 #ifdef DEBUG
     if(Ad.size() != Bd.size())
         throw std::runtime_error("mismatched sizes in MatrixRef/Matrix call_daxpy");
-    if(Ad.size() > std::numeric_limits<LAPACK_INT>::max()) 
-        throw std::runtime_error("overflow of size beyond LAPACK_INT range");
+    if(Ad.size() > std::numeric_limits<unsigned long>::max()) 
+        throw std::runtime_error("overflow of size beyond long unsigned int range");
 #endif
     daxpy_wrapper(Ad.size(),alpha,Bd.data(),inc,Ad.data(),inc);
     }

--- a/itensor/tensor/vec.cc
+++ b/itensor/tensor/vec.cc
@@ -78,8 +78,8 @@ multReal(VecRef<V> const& v, Real fac)
     if(isContiguous(v))
         {
 #ifdef DEBUG
-        if(v.size() > std::numeric_limits<LAPACK_INT>::max()) 
-            throw std::runtime_error("VectorRef overflow of size beyond LAPACK_INT range");
+        if(v.size() > std::numeric_limits<unsigned long>::max()) 
+            throw std::runtime_error("VectorRef overflow of size beyond long unsigned int range");
 #endif
         auto d = realData(v);
         dscal_wrapper(d.size(),fac,d.data());
@@ -152,8 +152,8 @@ call_daxpy(VectorRef& A, const VectorRefc& B, Real alpha_)
     LAPACK_INT inc = 1;
     LAPACK_INT size = A.size();
 #ifdef DEBUG
-    if(A.size() > std::numeric_limits<LAPACK_INT>::max()) 
-        throw std::runtime_error("overflow of size beyond LAPACK_INT range");
+    if(A.size() > std::numeric_limits<unsigned long>::max()) 
+        throw std::runtime_error("overflow of size beyond long unsigned int range");
 #endif
     daxpy_wrapper(size,alpha,B.data(),inc,A.data(),inc);
     }
@@ -216,8 +216,8 @@ operator*(VectorRefc a, VectorRefc b)
     {
 #ifdef DEBUG
     if(a.size() != b.size()) throw std::runtime_error("VectorRef dot product: mismatched sizes");
-    if(a.size() > std::numeric_limits<LAPACK_INT>::max()) 
-        throw std::runtime_error("VectorRef dot product: overflow of size beyond LAPACK_INT range");
+    if(a.size() > std::numeric_limits<unsigned long>::max()) 
+        throw std::runtime_error("VectorRef dot product: overflow of size beyond long unsigned int range");
 #endif
     return ddot_wrapper(a.size(),a.data(),stride(a),b.data(),stride(b));
     }
@@ -227,8 +227,8 @@ operator*(CVectorRefc a, CVectorRefc b)
     {
 #ifdef DEBUG
     if(a.size() != b.size()) throw std::runtime_error("VectorRef dot product: mismatched sizes");
-    if(a.size() > std::numeric_limits<LAPACK_INT>::max()) 
-        throw std::runtime_error("VectorRef dot product: overflow of size beyond LAPACK_INT range");
+    if(a.size() > std::numeric_limits<unsigned long>::max()) 
+        throw std::runtime_error("VectorRef dot product: overflow of size beyond long unsigned int range");
 #endif
     return zdotc_wrapper(a.size(),a.data(),stride(a),b.data(),stride(b));
     }


### PR DESCRIPTION
.size() returns a unsigned long int, so to detect the overflow it should be compared with the same variable type.