### PR TITLE
Use aggregate initialization instead of default initialization that l…

### DIFF
--- a/itensor/util/infarray.h
+++ b/itensor/util/infarray.h
@@ -53,7 +53,7 @@ class InfArray
     private:
     pointer data_ = nullptr;
     size_t size_ = 0;
-    array_type arr_;
+    array_type arr_{};
     std::vector<T> vec_;
     public:
 


### PR DESCRIPTION
…eaves simple types undefined. The problem with the default initialization is it calls value initialization, which leaves simple types undefined.  This gives a compilation error when Block(0) is being moved.  Changing it to aggregate initialization forces elements to be zero initialized.  The time penalty of constructing the arr_ array should be minimal.
