### PR TITLE
Added TAGS file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ tutorial/finiteT/ancilla
 tutorial/finiteT/en.dat
 tutorial/finiteT/metts
 tutorial/finiteT/sus.dat
+TAGS


### PR DESCRIPTION
The TAGS file allows easy jumping to the definition.  It can be automatically created by the ctags program. It should be ignored for git purposes.