### PR TITLE
HDF5 for dense real ITensors

### DIFF
--- a/itensor/index.cc
+++ b/itensor/index.cc
@@ -757,6 +757,7 @@ h5_write(h5::group parent, std::string const& name, Index const& I)
     h5_write(g,"id",static_cast<unsigned long>(I.id()));
     h5_write(g,"dim",long(I.dim()));
     h5_write(g,"dir",long(I.dir()));
+    h5_write(g,"plev",long(I.primeLevel()));
     h5_write(g,"tags",I.tags());
     }
 
@@ -771,6 +772,8 @@ h5_read(h5::group parent, std::string const& name, Index & I)
     auto dir = h5_read<long>(g,"dir");
     auto tags = h5_read<TagSet>(g,"tags");
     I = Index(id,dim,toArrow(dir),tags);
+    auto plev = h5_read<long>(g,"plev");
+    I.setPrime(plev);
     }
 
 #endif

--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -463,9 +463,7 @@ h5_read(h5::group parent, std::string const& name, DenseReal & D)
     {
     auto g = parent.open_group(name);
     auto type = h5_read_attribute<string>(g,"type");
-    if(type != "Dense") Error("Group does not contain Dense data in HDF5 file");
-    auto eltype = h5_read_attribute<string>(g,"eltype");
-    if(eltype != "Float64") Error("Group does not contain Dense Float64 data in HDF5 file");
+    if(type != "Dense{Float64}") Error("Group does not contain DenseReal data in HDF5 file");
     auto data = h5_read<vector<Real>>(g,"data");
     D = Dense<Real>(move(data));
     }

--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -441,6 +441,24 @@ template void doTask(Order const&,Dense<Cplx> &);
 #ifdef ITENSOR_USE_HDF5
 
 void
+h5_write(h5::group parent, std::string const& name, DenseReal const& D)
+    {
+    auto g = parent.create_group(name);
+    h5_write_attribute(g,"type","Dense{Float64}",true);
+    h5_write_attribute(g,"version",long(1));
+    auto data = std::vector<Real>(D.store.begin(),D.store.end());
+    h5_write(g,"data",data);
+    }
+void
+h5_write(h5::group parent, std::string const& name, DenseCplx const& D)
+    {
+    auto g = parent.create_group(name);
+    h5_write_attribute(g,"type","Dense{ComplexF64}",true);
+    h5_write_attribute(g,"version",long(1));
+    error("h5_write of complex dense storage not yet implemented");
+    }
+
+void
 h5_read(h5::group parent, std::string const& name, DenseReal & D)
     {
     auto g = parent.open_group(name);

--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -452,6 +452,18 @@ h5_read(h5::group parent, std::string const& name, DenseReal & D)
     D = Dense<Real>(move(data));
     }
 
+void
+h5_read(h5::group parent, std::string const& name, DenseCplx & D)
+    {
+    auto g = parent.open_group(name);
+    auto type = h5_read_attribute<string>(g,"type");
+    if(type != "Dense") Error("Group does not contain Dense data in HDF5 file");
+    auto eltype = h5_read_attribute<string>(g,"eltype");
+    if(eltype != "Complex{Float64}") Error("Group does not contain Dense Complex{Float64} data in HDF5 file");
+    auto data = h5_read<vector<Cplx>>(g,"data");
+    D = Dense<Cplx>(move(data));
+    }
+
 #endif //ITENSOR_USE_HDF5
 
 } // namespace itensor

--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -23,6 +23,10 @@
 #include "itensor/tensor/lapack_wrap.h"
 #include "itensor/util/tensorstats.h"
 
+using std::move;
+using std::string;
+using std::vector;
+
 namespace itensor {
 
 const char*
@@ -427,5 +431,21 @@ doTask(Order const& O,
     }
 template void doTask(Order const&,Dense<Real> &);
 template void doTask(Order const&,Dense<Cplx> &); 
+
+#ifdef ITENSOR_USE_HDF5
+
+void
+h5_read(h5::group parent, std::string const& name, DenseReal & D)
+    {
+    auto g = parent.open_group(name);
+    auto type = h5_read_attribute<string>(g,"type");
+    if(type != "Dense") Error("Group does not contain Dense data in HDF5 file");
+    auto eltype = h5_read_attribute<string>(g,"eltype");
+    if(eltype != "Float64") Error("Group does not contain Dense Float64 data in HDF5 file");
+    auto data = h5_read<vector<Real>>(g,"data");
+    D = Dense<Real>(move(data));
+    }
+
+#endif //ITENSOR_USE_HDF5
 
 } // namespace itensor

--- a/itensor/itdata/dense.h
+++ b/itensor/itdata/dense.h
@@ -331,6 +331,10 @@ permuteDense(Permutation const& P,
 
 #ifdef ITENSOR_USE_HDF5
 void
+h5_write(h5::group parent, std::string const& name, DenseReal const& D);
+void
+h5_write(h5::group parent, std::string const& name, DenseCplx const& D);
+void
 h5_read(h5::group parent, std::string const& name, DenseReal & D);
 void
 h5_read(h5::group parent, std::string const& name, DenseCplx & D);

--- a/itensor/itdata/dense.h
+++ b/itensor/itdata/dense.h
@@ -330,6 +330,11 @@ permuteDense(Permutation const& P,
              Dense<T>        & dB,
              IndexSet   const& Bis);
 
+#ifdef ITENSOR_USE_HDF5
+void
+h5_read(h5::group parent, std::string const& name, DenseReal & D);
+#endif
+
 } //namespace itensor
 
 #endif

--- a/itensor/itdata/dense.h
+++ b/itensor/itdata/dense.h
@@ -332,6 +332,8 @@ permuteDense(Permutation const& P,
 #ifdef ITENSOR_USE_HDF5
 void
 h5_read(h5::group parent, std::string const& name, DenseReal & D);
+void
+h5_read(h5::group parent, std::string const& name, DenseCplx & D);
 #endif
 
 } //namespace itensor

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -831,25 +831,17 @@ h5_read(h5::group parent, std::string const& name, ITensor & I)
 
     auto is = h5_read<IndexSet>(g,"inds");
 
-    //TODO: check if this group is called "store"
-    //      instead, as in some older versions 
-    //      of ITensors.jl
-    auto store_name = "storage";
+    std::string store_name;
+    if(g.has_subgroup("storage"))    store_name = "storage";
+    else if(g.has_subgroup("store")) store_name = "store";
+    else error("Expected ITensor HDF5 data to have group named \"storage\" or \"store\"");
+
     auto sg = g.open_group(store_name);
     auto s_type = h5_read_attribute<string>(sg,"type");
     ITensor::storage_ptr store;
-    if(s_type == "Dense{Float64}")
-        { 
-        store = h5_readStore<DenseReal>(g,store_name); 
-        }
-    //else if(s_type == "Dense{ComplexF64}")
-    //    { 
-    //    store = h5_readType<DenseCplx>(g,store_name); 
-    //    }
-    else
-        {
-        error(format("Reading of ITensor storage type %s not yet supported",s_type));
-        }
+    if(s_type == "Dense{Float64}") store = h5_readStore<DenseReal>(g,store_name); 
+    //else if(s_type == "Dense{ComplexF64}") store = h5_readType<DenseCplx>(g,store_name); 
+    else error(format("Reading of ITensor storage type %s not yet supported",s_type));
 
     I = ITensor(is,std::move(store));
     }

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -834,17 +834,21 @@ h5_read(h5::group parent, std::string const& name, ITensor & I)
     //TODO: check if this group is called "store"
     //      instead, as in some older versions 
     //      of ITensors.jl
-    auto sg = g.open_group("storage");
+    auto store_name = "storage";
+    auto sg = g.open_group(store_name);
     auto s_type = h5_read_attribute<string>(sg,"type");
-    auto s_eltype = h5_read_attribute<string>(sg,"eltype");
     ITensor::storage_ptr store;
-    if(s_type == "Dense" && s_eltype == "Float64") 
+    if(s_type == "Dense{Float64}")
         { 
-        store = h5_readType<DenseReal>(g,"store"); 
+        store = h5_readStore<DenseReal>(g,store_name); 
         }
-    else if(s_type == "Dense" && s_eltype == "Complex{Float64}") 
-        { 
-        store = h5_readType<DenseCplx>(g,"store"); 
+    //else if(s_type == "Dense{ComplexF64}")
+    //    { 
+    //    store = h5_readType<DenseCplx>(g,store_name); 
+    //    }
+    else
+        {
+        error(format("Reading of ITensor storage type %s not yet supported",s_type));
         }
 
     I = ITensor(is,std::move(store));

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -812,17 +812,15 @@ read(std::istream& s)
 
 #ifdef ITENSOR_USE_HDF5
 
-//void
-//h5_write(h5::group parent, std::string const& name, ITensor const& I)
-//    {
-//    auto g = parent.create_group(name);
-//    h5_write_attribute(g,"type","Index",true);
-//    h5_write_attribute(g,"version",long(1));
-//    h5_write(g,"id",static_cast<unsigned long>(I.id()));
-//    h5_write(g,"dim",long(I.dim()));
-//    h5_write(g,"dir",long(I.dir()));
-//    h5_write(g,"tags",I.tags());
-//    }
+void
+h5_write(h5::group parent, std::string const& name, ITensor const& T)
+    {
+    auto g = parent.create_group(name);
+    h5_write_attribute(g,"type","ITensor",true);
+    h5_write_attribute(g,"version",long(1));
+    h5_write(g,"inds",T.inds());
+    doTask(H5Write(g,"storage"),T.store());
+    }
 
 void
 h5_read(h5::group parent, std::string const& name, ITensor & I)
@@ -833,7 +831,10 @@ h5_read(h5::group parent, std::string const& name, ITensor & I)
 
     auto is = h5_read<IndexSet>(g,"inds");
 
-    auto sg = g.open_group("store");
+    //TODO: check if this group is called "store"
+    //      instead, as in some older versions 
+    //      of ITensors.jl
+    auto sg = g.open_group("storage");
     auto s_type = h5_read_attribute<string>(sg,"type");
     auto s_eltype = h5_read_attribute<string>(sg,"eltype");
     ITensor::storage_ptr store;

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -841,6 +841,10 @@ h5_read(h5::group parent, std::string const& name, ITensor & I)
         { 
         store = h5_readType<DenseReal>(g,"store"); 
         }
+    else if(s_type == "Dense" && s_eltype == "Complex{Float64}") 
+        { 
+        store = h5_readType<DenseCplx>(g,"store"); 
+        }
 
     I = ITensor(is,std::move(store));
     }

--- a/itensor/itensor.h
+++ b/itensor/itensor.h
@@ -1096,8 +1096,8 @@ ITensor
 matrixTensor(CMatrix const& M, Index const& i1, Index const& i2);
 
 #ifdef ITENSOR_USE_HDF5
-//void
-//h5_write(h5::group parent, std::string const& name, ITensor const& I);
+void
+h5_write(h5::group parent, std::string const& name, ITensor const& I);
 void
 h5_read(h5::group parent, std::string const& name, ITensor & I);
 #endif //ITENSOR_USE_HDF5

--- a/itensor/itensor.h
+++ b/itensor/itensor.h
@@ -1091,6 +1091,13 @@ matrixTensor(CMatrix && M, Index const& i1, Index const& i2);
 ITensor
 matrixTensor(CMatrix const& M, Index const& i1, Index const& i2);
 
+#ifdef ITENSOR_USE_HDF5
+//void
+//h5_write(h5::group parent, std::string const& name, ITensor const& I);
+void
+h5_read(h5::group parent, std::string const& name, ITensor & I);
+#endif //ITENSOR_USE_HDF5
+
 } //namespace itensor
 
 #include "itensor_impl.h"

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -540,7 +540,7 @@ readType(std::istream& s, CtrArgs&&... args)
 
 template<typename T>
 ITensor::storage_ptr
-h5_readType(h5::group g, std::string const& name)
+h5_readStore(h5::group g, std::string const& name)
     {
     return newITData<T>(h5_read<T>(g,name));
     }

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -529,6 +529,16 @@ readType(std::istream& s, CtrArgs&&... args)
     return newITData<T>(std::move(t));
     }
 
+#ifdef ITENSOR_USE_HDF5
+
+template<typename T>
+ITensor::storage_ptr
+h5_readType(h5::group g, std::string const& name)
+    {
+    return newITData<T>(h5_read<T>(g,name));
+    }
+
+#endif
 
 struct Write
     {

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -564,6 +564,28 @@ doTask(Write & W, D const& d)
     write(W.s,d);
     }
 
+#ifdef ITENSOR_USE_HDF5
+
+struct H5Write
+    {
+    h5::group& parent;
+    std::string name;
+
+    H5Write(h5::group& parent_,std::string const& name_) : parent(parent_), name(name_) { }
+    };
+inline const char*
+typeNameOf(H5Write const&) { return "H5Write"; }
+
+template<typename D>
+auto
+doTask(H5Write & W, D const& d)
+    -> stdx::if_compiles_return<void,decltype(itensor::h5_write(W.parent,W.name,d))>
+    {
+    h5_write(W.parent,W.name,d);
+    }
+
+#endif 
+
 template<typename Container, class>
 ITensor
 diagITensor(Container const& C, 

--- a/unittest/hdf5_test.cc
+++ b/unittest/hdf5_test.cc
@@ -1,6 +1,7 @@
 #include "test.h"
 
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace std;
 using namespace itensor;
@@ -18,7 +19,7 @@ SECTION("TagSet")
 
     auto fi = h5_open("test.h5",'r');
     auto ti = h5_read<TagSet>(fi,"tagset");
-    close(fi);
+    //close(fi);
 
     CHECK(ti == to);
     }
@@ -32,7 +33,7 @@ SECTION("Index")
 
     auto fi = h5_open("test.h5",'r');
     auto ii = h5_read<Index>(fi,"index");
-    close(fi);
+    //close(fi);
 
     CHECK(ii == io);
     }
@@ -49,12 +50,36 @@ SECTION("IndexSet")
 
     auto fi = h5_open("test.h5",'r');
     auto isi = h5_read<IndexSet>(fi,"indexset");
-    close(fi);
+    //close(fi);
 
     for(auto n : range1(iso.length()))
         {
         CHECK(isi(n) == iso(n));
         }
+    }
+
+SECTION("ITensor")
+    {
+    auto i2 = Index(2,"n=2,Blue");
+    auto i3 = Index(3,"n=2,Red");
+
+    auto R = ITensor(i2,i3);
+    auto n = 1;
+    for(auto n2 : range1(i2.dim()))
+    for(auto n3 : range1(i3.dim()))
+        {
+        R.set(i2=n2,i3=n3,n);
+        n += 1;
+        }
+
+    auto fo = h5_open("test.h5",'w');
+    h5_write(fo,"itensor_R",R);
+    close(fo);
+
+    auto fi = h5_open("test.h5",'r');
+    auto read_R = h5_read<ITensor>(fi,"itensor_R");
+
+    CHECK(norm(R-read_R) < 1E-10);
     }
 
 }


### PR DESCRIPTION
Adds support for writing and reading dense, real ITensors to HDF5 files. Compatible with the format used for ITensors.jl version 0.2.

- Started working on HDF5 read of ITensor
- Began adding support for Dense complex HDF5
- Update Index h5 functions to include prime level
- Define h5_write for DenseReal
- Implement h5_write for ITensor type
- Update reading of Dense storage
- Update reading of ITensor HDF5 data and test
