### PR TITLE
[C++20] Replace `result_of` with `invoke_result` when using C++ > 17

### DIFF
--- a/itensor/detail/call_rewrite.h
+++ b/itensor/detail/call_rewrite.h
@@ -55,7 +55,7 @@ call_impl(T&& obj, V&& v, long)
     return Ret();
     }
 template <typename Ret, class T, typename V>
-stdx::enable_if_t<std::is_same<typename std::result_of<T(V)>::type,void>::value,Ret>
+stdx::enable_if_t<std::is_same<stdx::invoke_result_t<T,V>,void>::value,Ret>
 fixret(T&& obj, V&& v, int)
     {
     call_impl<void,T,V>(std::forward<T>(obj),std::forward<V>(v),0);
@@ -140,7 +140,7 @@ call_impl(FType&& func, T1&& a1, T2&& a2, long)
     return Ret();
     }
 template <typename Ret, class FType, typename T1, typename T2>
-stdx::enable_if_t<std::is_same<typename std::result_of<FType(T1,T2)>::type,void>::value,Ret>
+stdx::enable_if_t<std::is_same<stdx::invoke_result_t<FType,T1,T2>,void>::value,Ret>
 fixret(FType&& func, T1&& a1, T2&& a2, int)
     {
     call_impl<void,FType,T1,T2>(std::forward<FType>(func),

--- a/itensor/detail/call_rewrite.h
+++ b/itensor/detail/call_rewrite.h
@@ -55,7 +55,7 @@ call_impl(T&& obj, V&& v, long)
     return Ret();
     }
 template <typename Ret, class T, typename V>
-stdx::enable_if_t<std::is_same<stdx::invoke_result_t<T,V>,void>::value,Ret>
+stdx::enable_if_t<std::is_same<std::invoke_result_t<T,V>,void>::value,Ret>
 fixret(T&& obj, V&& v, int)
     {
     call_impl<void,T,V>(std::forward<T>(obj),std::forward<V>(v),0);
@@ -140,7 +140,7 @@ call_impl(FType&& func, T1&& a1, T2&& a2, long)
     return Ret();
     }
 template <typename Ret, class FType, typename T1, typename T2>
-stdx::enable_if_t<std::is_same<stdx::invoke_result_t<FType,T1,T2>,void>::value,Ret>
+stdx::enable_if_t<std::is_same<std::invoke_result_t<FType,T1,T2>,void>::value,Ret>
 fixret(FType&& func, T1&& a1, T2&& a2, int)
     {
     call_impl<void,FType,T1,T2>(std::forward<FType>(func),

--- a/itensor/itdata/dotask.h
+++ b/itensor/itdata/dotask.h
@@ -312,23 +312,23 @@ struct HasDTHelper
 template<typename Task, typename Storage>
 struct HasConstDoTask
     {
-    using ResultType = stdx::invoke_result_t<HasDTHelper<Task,const Storage>>;
+    using ResultType = std::invoke_result_t<HasDTHelper<Task,const Storage>>;
     bool constexpr static
     result() { return ResultType{}; }
     };
 template<typename Task, typename Storage>
 struct HasNonConstDoTask
     {
-    using ResultType = stdx::invoke_result_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>>;
-    using CResultType = stdx::invoke_result_t<HasDTHelper<Task,const Storage>>;
+    using ResultType = std::invoke_result_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>>;
+    using CResultType = std::invoke_result_t<HasDTHelper<Task,const Storage>>;
     bool constexpr static
     result() { return ResultType{} && (not CResultType{}); }
     };
 template<typename Task, typename Storage>
 struct HasDoTask
     {
-    using CResultType = stdx::invoke_result_t<HasDTHelper<Task,const Storage>>;
-    using NCResultType = stdx::invoke_result_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>>;
+    using CResultType = std::invoke_result_t<HasDTHelper<Task,const Storage>>;
+    using NCResultType = std::invoke_result_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>>;
     using ResultType = stdx::conditional_t<CResultType::value,
                                           CResultType,
                                           NCResultType>;
@@ -372,23 +372,23 @@ struct HasDTHelper2Arg
 template<typename Task, typename D1, typename D2>
 struct HasConstDoTask2Arg
     {
-    using ResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,const D1, const D2>>;
+    using ResultType = std::invoke_result_t<HasDTHelper2Arg<Task,const D1, const D2>>;
     bool constexpr static
     result() { return ResultType{}; }
     };
 template<typename Task, typename D1, typename D2>
 struct HasNonConstDoTask2Arg
     {
-    using ResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>>;
-    using CResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,const D1,D2>>;
+    using ResultType = std::invoke_result_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>>;
+    using CResultType = std::invoke_result_t<HasDTHelper2Arg<Task,const D1,D2>>;
     bool constexpr static
     result() { return ResultType{} && (not CResultType{}); }
     };
 template<typename Task, typename D1, typename D2>
 struct HasDoTask2Arg
     {
-    using CResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,const D1,D2>>;
-    using NCResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>>;
+    using CResultType = std::invoke_result_t<HasDTHelper2Arg<Task,const D1,D2>>;
+    using NCResultType = std::invoke_result_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>>;
     using ResultType = stdx::conditional_t<CResultType::value,
                                           CResultType,
                                           NCResultType>;
@@ -422,7 +422,7 @@ struct HasEvaluate
             { return testEvalImpl(stdx::select_overload{},*s); }
         };
     bool constexpr static
-    result() { return stdx::invoke_result_t<Test>{}; }
+    result() { return std::invoke_result_t<Test>{}; }
     };
 
 /////////////

--- a/itensor/itdata/dotask.h
+++ b/itensor/itdata/dotask.h
@@ -312,23 +312,23 @@ struct HasDTHelper
 template<typename Task, typename Storage>
 struct HasConstDoTask
     {
-    using ResultType = stdx::result_of_t<HasDTHelper<Task,const Storage>()>;
+    using ResultType = stdx::invoke_result_t<HasDTHelper<Task,const Storage>>;
     bool constexpr static
     result() { return ResultType{}; }
     };
 template<typename Task, typename Storage>
 struct HasNonConstDoTask
     {
-    using ResultType = stdx::result_of_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>()>;
-    using CResultType = stdx::result_of_t<HasDTHelper<Task,const Storage>()>;
+    using ResultType = stdx::invoke_result_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>>;
+    using CResultType = stdx::invoke_result_t<HasDTHelper<Task,const Storage>>;
     bool constexpr static
     result() { return ResultType{} && (not CResultType{}); }
     };
 template<typename Task, typename Storage>
 struct HasDoTask
     {
-    using CResultType = stdx::result_of_t<HasDTHelper<Task,const Storage>()>;
-    using NCResultType = stdx::result_of_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>()>;
+    using CResultType = stdx::invoke_result_t<HasDTHelper<Task,const Storage>>;
+    using NCResultType = stdx::invoke_result_t<HasDTHelper<Task,stdx::remove_const_t<Storage>>>;
     using ResultType = stdx::conditional_t<CResultType::value,
                                           CResultType,
                                           NCResultType>;
@@ -372,23 +372,23 @@ struct HasDTHelper2Arg
 template<typename Task, typename D1, typename D2>
 struct HasConstDoTask2Arg
     {
-    using ResultType = stdx::result_of_t<HasDTHelper2Arg<Task,const D1, const D2>()>;
+    using ResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,const D1, const D2>>;
     bool constexpr static
     result() { return ResultType{}; }
     };
 template<typename Task, typename D1, typename D2>
 struct HasNonConstDoTask2Arg
     {
-    using ResultType = stdx::result_of_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>()>;
-    using CResultType = stdx::result_of_t<HasDTHelper2Arg<Task,const D1,D2>()>;
+    using ResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>>;
+    using CResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,const D1,D2>>;
     bool constexpr static
     result() { return ResultType{} && (not CResultType{}); }
     };
 template<typename Task, typename D1, typename D2>
 struct HasDoTask2Arg
     {
-    using CResultType = stdx::result_of_t<HasDTHelper2Arg<Task,const D1,D2>()>;
-    using NCResultType = stdx::result_of_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>()>;
+    using CResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,const D1,D2>>;
+    using NCResultType = stdx::invoke_result_t<HasDTHelper2Arg<Task,stdx::remove_const_t<D1>,D2>>;
     using ResultType = stdx::conditional_t<CResultType::value,
                                           CResultType,
                                           NCResultType>;
@@ -422,7 +422,7 @@ struct HasEvaluate
             { return testEvalImpl(stdx::select_overload{},*s); }
         };
     bool constexpr static
-    result() { return stdx::result_of_t<Test()>{}; }
+    result() { return stdx::invoke_result_t<Test>{}; }
     };
 
 /////////////

--- a/itensor/itdata/returntype.h
+++ b/itensor/itdata/returntype.h
@@ -82,7 +82,7 @@ struct TestRet
 template<typename Task, typename TList>
 struct GetRType : GetRType<Task,popFront<TList>>
     {
-    using Test = stdx::invoke_result_t<TestRet<Task,frontType<TList>>>;
+    using Test = std::invoke_result_t<TestRet<Task,frontType<TList>>>;
     using Parent = GetRType<Task,popFront<TList>>;
     using RType = stdx::conditional_t<not std::is_same<Test,NoneType>::value,
                                      Test,

--- a/itensor/itdata/returntype.h
+++ b/itensor/itdata/returntype.h
@@ -82,7 +82,7 @@ struct TestRet
 template<typename Task, typename TList>
 struct GetRType : GetRType<Task,popFront<TList>>
     {
-    using Test = stdx::result_of_t<TestRet<Task,frontType<TList>>()>;
+    using Test = stdx::invoke_result_t<TestRet<Task,frontType<TList>>>;
     using Parent = GetRType<Task,popFront<TList>>;
     using RType = stdx::conditional_t<not std::is_same<Test,NoneType>::value,
                                      Test,

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -239,7 +239,7 @@ using ApplyIT_result_of = decltype(resultTypeHelper<T>(std::declval<ApplyIT<F>>(
 ///////////////////
 
 
-template<typename F, typename T = typename stdx::invoke_result_t<F>>
+template<typename F, typename T = typename std::invoke_result_t<F>>
 struct GenerateIT
     {
     F& f;

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -239,7 +239,7 @@ using ApplyIT_result_of = decltype(resultTypeHelper<T>(std::declval<ApplyIT<F>>(
 ///////////////////
 
 
-template<typename F, typename T = typename std::result_of<F()>::type>
+template<typename F, typename T = typename stdx::invoke_result_t<F>>
 struct GenerateIT
     {
     F& f;

--- a/itensor/util/itertools.h
+++ b/itensor/util/itertools.h
@@ -26,6 +26,23 @@
 
 namespace triqs::utility {
 
+  /********************* Custom Trait Types ********************/
+
+  namespace stdx {
+
+  #if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
+    // std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
+    // replaced with std::invoke_result here. Also *_t format is preferred over
+    // typename *::type format.
+    template<class F, class... TN>
+    using invoke_result_t = typename std::invoke_result<F, TN...>::type;
+  #else
+    template<class F, class... TN>
+    using invoke_result_t = typename std::result_of<F(TN...)>::type;
+  #endif
+
+  }
+
   template <class Iter, class Value, class Tag = std::forward_iterator_tag, class Reference = Value &, class Difference = std::ptrdiff_t>
   struct iterator_facade;
 
@@ -92,7 +109,7 @@ namespace triqs::utility {
 
   /********************* Transform Iterator ********************/
 
-  template <typename Iter, typename L, typename Value = std::result_of<L(typename std::iterator_traits<Iter>::value_type)>>
+  template <typename Iter, typename L, typename Value = stdx::invoke_result_t<L,typename std::iterator_traits<Iter>::value_type>>
   struct transform_iter : iterator_facade<transform_iter<Iter, L>, Value> {
 
     Iter it;

--- a/itensor/util/itertools.h
+++ b/itensor/util/itertools.h
@@ -26,23 +26,6 @@
 
 namespace triqs::utility {
 
-  /********************* Custom Trait Types ********************/
-
-  namespace stdx {
-
-  #if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
-    // std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
-    // replaced with std::invoke_result here. Also *_t format is preferred over
-    // typename *::type format.
-    template<class F, class... TN>
-    using invoke_result_t = typename std::invoke_result<F, TN...>::type;
-  #else
-    template<class F, class... TN>
-    using invoke_result_t = typename std::result_of<F(TN...)>::type;
-  #endif
-
-  }
-
   template <class Iter, class Value, class Tag = std::forward_iterator_tag, class Reference = Value &, class Difference = std::ptrdiff_t>
   struct iterator_facade;
 
@@ -109,7 +92,7 @@ namespace triqs::utility {
 
   /********************* Transform Iterator ********************/
 
-  template <typename Iter, typename L, typename Value = stdx::invoke_result_t<L,typename std::iterator_traits<Iter>::value_type>>
+  template <typename Iter, typename L, typename Value = std::invoke_result_t<L,typename std::iterator_traits<Iter>::value_type>>
   struct transform_iter : iterator_facade<transform_iter<Iter, L>, Value> {
 
     Iter it;

--- a/itensor/util/stdx.h
+++ b/itensor/util/stdx.h
@@ -47,6 +47,17 @@ using conditional_t = typename std::conditional<B,T1,T2>::type;
 template<bool B, typename T1, typename T2>
 using conditional_t = typename std::conditional<B,T1,T2>::type;
 
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
+    // std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
+    // replaced with std::invoke_result here. Also *_t format is preferred over
+    // typename *::type format.
+    template<class F, class... TN>
+    using invoke_result_t = typename std::invoke_result<F, TN...>::type;
+#else
+    template<class F, class... TN>
+    using invoke_result_t = typename std::result_of<F(TN...)>::type;
+#endif
+
 template<class T>
 using result_of_t = typename std::result_of<T>::type;
 

--- a/itensor/util/stdx.h
+++ b/itensor/util/stdx.h
@@ -47,20 +47,6 @@ using conditional_t = typename std::conditional<B,T1,T2>::type;
 template<bool B, typename T1, typename T2>
 using conditional_t = typename std::conditional<B,T1,T2>::type;
 
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
-    // std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
-    // replaced with std::invoke_result here. Also *_t format is preferred over
-    // typename *::type format.
-    template<class F, class... TN>
-    using invoke_result_t = typename std::invoke_result<F, TN...>::type;
-#else
-    template<class F, class... TN>
-    using invoke_result_t = typename std::result_of<F(TN...)>::type;
-#endif
-
-template<class T>
-using result_of_t = typename std::result_of<T>::type;
-
 template<typename... Conds>
 struct all
     {

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -64,7 +64,7 @@ trg-g: mkdebugdir .debug_objs/trg.o $(ITENSOR_GLIBS) $(TENSOR_HEADERS)
 ctmrg: ctmrg.o $(ITENSOR_LIBS) $(TENSOR_HEADERS)
 	$(CCCOM) $(CCFLAGS) ctmrg.o -o ctmrg $(LIBFLAGS)
 
-ctmrg-g: mkdebugdir .debug_objs/trg.o $(ITENSOR_GLIBS) $(TENSOR_HEADERS)
+ctmrg-g: mkdebugdir .debug_objs/ctmrg.o $(ITENSOR_GLIBS) $(TENSOR_HEADERS)
 	$(CCCOM) $(CCGFLAGS) .debug_objs/ctmrg.o -o ctmrg-g $(LIBGFLAGS)
 
 hubbard_2d: hubbard_2d.o $(ITENSOR_LIBS) $(TENSOR_HEADERS)


### PR DESCRIPTION
For version of C++ greater than 17, replace the use of `result_of` with `invoke_result` since it is removed in C++20.