### PR TITLE
randomMPS: fix (N-1)-th bond dimension

### DIFF
--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -227,6 +227,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
 
     //Make N'th MPS tensor
     int chi = dim(s(N));
+    chi = std::min(m,chi);
     l[N-1] = Index(chi,format("Link,l=%d",N-1));
     auto O = randomOrthog(chi,dim(s(N)));
     M.ref(N) = matrixITensor(O,l[N-1],s(N));

--- a/unittest/mps_test.cc
+++ b/unittest/mps_test.cc
@@ -169,6 +169,20 @@ SECTION("Random constructors, QN conserved (dim==1)")
     CHECK(checkTags(psi));
     }
 
+SECTION("Random with prescribed bond dimensions")
+    {
+    auto psi = randomMPS(shsites,1);
+    for(auto n : range1(N-1))
+      {
+      CHECK_EQUAL(1,dim(linkIndex(psi,n)));
+      }
+    psi = randomMPS(shsites,2);
+    for(auto n : range1(N-1))
+      {
+      CHECK_EQUAL(2,dim(linkIndex(psi,n)));
+      }
+    }
+
 SECTION("MPSAddition 1")
     {
     auto sites = Fermion(10);


### PR DESCRIPTION
For dimension n bigger than the desired bond_dim, the last bond dimension is too big.