### PR TITLE
Proposal for SiteSet simplification.

### DIFF
--- a/itensor/mps/sites/Z3.h
+++ b/itensor/mps/sites/Z3.h
@@ -24,7 +24,7 @@ class Z3Site;
 
 using Z3 = BasicSiteSet<Z3Site>;
 
-class Z3Site
+class Z3Site : public virtual SiteBase
     {
     Index s;
     public:

--- a/itensor/mps/sites/boson.h
+++ b/itensor/mps/sites/boson.h
@@ -24,7 +24,7 @@ class BosonSite;
 
 using Boson = BasicSiteSet<BosonSite>;
 
-class BosonSite
+class BosonSite : public virtual SiteBase
     {
     Index s;
     public:

--- a/itensor/mps/sites/customspin.h
+++ b/itensor/mps/sites/customspin.h
@@ -12,7 +12,7 @@ class CustomSpinSite;
 
 using CustomSpin = BasicSiteSet<CustomSpinSite>;
 
-class CustomSpinSite
+class CustomSpinSite  : public virtual SiteBase
     {
     Index s;
     public:

--- a/itensor/mps/sites/electron.h
+++ b/itensor/mps/sites/electron.h
@@ -24,7 +24,7 @@ class ElectronSite;
 
 using Electron = BasicSiteSet<ElectronSite>;
 
-class ElectronSite
+class ElectronSite : public virtual SiteBase
     {
     Index s;
     public:

--- a/itensor/mps/sites/fermion.h
+++ b/itensor/mps/sites/fermion.h
@@ -24,7 +24,7 @@ class FermionSite;
 
 using Fermion = BasicSiteSet<FermionSite>;
 
-class FermionSite
+class FermionSite : public virtual SiteBase
     {
     Index s;
     public:

--- a/itensor/mps/sites/spinhalf.h
+++ b/itensor/mps/sites/spinhalf.h
@@ -24,7 +24,7 @@ class SpinHalfSite;
 
 using SpinHalf = BasicSiteSet<SpinHalfSite>;
 
-class SpinHalfSite
+class SpinHalfSite : public virtual SiteBase
     {
     Index s;
     public:

--- a/itensor/mps/sites/tj.h
+++ b/itensor/mps/sites/tj.h
@@ -24,7 +24,7 @@ class tJSite;
 
 using tJ  = BasicSiteSet<tJSite>;
 
-class tJSite
+class tJSite : public virtual SiteBase
     {
     Index s;
     public:

--- a/sample/src/electronk.h
+++ b/sample/src/electronk.h
@@ -24,7 +24,7 @@ class ElectronKSite;
 
 using ElectronK = BasicSiteSet<ElectronKSite>;
 
-class ElectronKSite
+class ElectronKSite : public virtual SiteBase
   {
   Index s;
   public:

--- a/unittest/siteset_test.cc
+++ b/unittest/siteset_test.cc
@@ -13,7 +13,9 @@ using namespace itensor;
 TEST_CASE("SiteSetTest")
 {
 
-const int N = 10;
+    const int N = 10;
+    std::string file_name("SiteSetIO.dat");
+
 
 SECTION("Generic SiteSet")
     {
@@ -161,5 +163,126 @@ SECTION("tJ")
     op(sites,"Adn",2); 
     op(sites,"F",2); 
     }
+
+
+    SECTION("Spin 1/2 legacy IO")
+    {
+        // Dump sites to disk
+        {
+            SiteSet sites=SpinHalf(N,{"ConserveQNs=",false});
+            std::ofstream file(file_name);
+            sites.write(file);
+        }
+        {
+            //Restore from Disk (sort of)
+            SiteSet sites;
+            std::ifstream file(file_name);
+            sites.read(file); //Creates a set of GenericSite objects.
+            CHECK(sites.length()==N);//This is the easy part.
+
+            // If we try and use the sites for something it fails with:
+            //       'op' method not defined for generic site
+    //        sites.op("Sz",1); //auto MPO will fail for the same reason.            
+        }
+        {
+            //Restore from Disk with hind sight about the SiteSet type.
+            SpinHalf sites;
+            std::ifstream file(file_name);
+            sites.read(file); //Creates a set of GenericSite objects.
+            CHECK(sites.length()==N);//This is the easy part.
+            sites.op("Sz",1); //auto MPO will fail for the same reason.            
+        }
+        {
+            //Restore from Disk with *incorrect* hind sight about the SiteSet type.
+            //SpinOne sites; this will actually work!! because of spin 1/2 the edge site handling code.
+            Electron sites;
+            std::ifstream file(file_name);
+            sites.read(file); //Creates a set of GenericSite objects.
+            CHECK(sites.length()==N);//This is the easy part.
+            //auto sz=sites.op("Sz",1); Out of range: IndexVal at position 1 has val 3 > (dim=2|id=646|"n=1,Site,S=1/2")      
+            //auto sx=sites.op("Sx",1); Not defined for Electron .. but it could be        
+            //auto nup=sites.op("Nup",1); Out of range: IndexVal at position 1 has val 4 > (dim=2|id=413|"n=1,Site,S=1/2")          
+        }
+
+        std::remove(file_name.c_str()); //cleanup (CATCH2 should provide some sort of teardown function for this?)
+    }
+
+    SECTION("Spin 1 no QNs legacy IO")
+    {
+        // Dump sites to disk
+        {
+            SiteSet sites=SpinOne(N,{"ConserveQNs=",false,"SHalfEdge",true});
+            std::ofstream file(file_name);
+            sites.write(file);
+        }
+        //Restore from Disk (sort of)
+        SiteSet sites;
+        std::ifstream file(file_name);
+        sites.read(file); //Creates a set of GenericSite objects.
+        CHECK(sites.length()==N);
+        CHECK(hasTags(sites(1  ),"S=1/2")); //Make sure we the edge spins correct after readback.
+        CHECK(hasTags(sites(2  ),"S=1"  ));
+        CHECK(hasTags(sites(N-1),"S=1"  ));
+        CHECK(hasTags(sites(N  ),"S=1/2"));
+        std::remove(file_name.c_str()); //cleanup (CATCH2 should provide some sort of teardown function for this?)
+    }
+    
+    SECTION("Spin 2 no QNs legacy IO")
+    {
+        // Dump sites to disk
+        {
+            SiteSet sites=SpinTwo(N,{"ConserveQNs=",false,"SHalfEdge",true});
+            std::ofstream file(file_name);
+            sites.write(file);
+        }
+        //Restore from Disk (sort of)
+        SiteSet sites;
+        std::ifstream file(file_name);
+        sites.read(file); //Creates a set of GenericSite objects.
+        CHECK(sites.length()==N);
+        CHECK(hasTags(sites(1  ),"S=1/2")); //Make sure we the edge spins correct after readback.
+        CHECK(hasTags(sites(2  ),"S=2"  ));
+        CHECK(hasTags(sites(N-1),"S=2"  ));
+        CHECK(hasTags(sites(N  ),"S=1/2"));
+        std::remove(file_name.c_str()); //cleanup (CATCH2 should provide some sort of teardown function for this?)
+    }
+
+    SECTION("Spin 1 with QNs legacy IO")
+    {
+        // Dump sites to disk
+        {
+            SiteSet sites=SpinOne(N,{"ConserveQNs=",true,"SHalfEdge",true});
+            std::ofstream file(file_name);
+            sites.write(file);
+        }
+        //Restore from Disk (sort of)
+        SiteSet sites;
+        std::ifstream file(file_name);
+        sites.read(file); //Creates a set of GenericSite objects.
+        CHECK(sites.length()==N);
+        
+        //Make sure we the edge spins correct after readback.
+        CHECK(hasTags(sites(1  ),"S=1/2")); 
+        CHECK(hasTags(sites(2  ),"S=1"  ));
+        CHECK(hasTags(sites(N-1),"S=1"  ));
+        CHECK(hasTags(sites(N  ),"S=1/2"));
+        
+        //Make sure the edge spins correct QNs after readback.
+        CHECK(hasQNs(sites));
+        CHECK(sites(1).qn(1).store()[0].name()=="Sz");
+        CHECK(sites(1).qn(1).store()[0].val ()==1);
+        CHECK(sites(1).qn(2).store()[0].name()=="Sz");
+        CHECK(sites(1).qn(2).store()[0].val ()==-1);
+        CHECK(sites(2).qn(1).store()[0].name()=="Sz");
+        CHECK(sites(2).qn(1).store()[0].val ()==2);
+        CHECK(sites(2).qn(2).store()[0].name()=="Sz");
+        CHECK(sites(2).qn(2).store()[0].val ()==0);
+        CHECK(sites(2).qn(3).store()[0].name()=="Sz");
+        CHECK(sites(2).qn(3).store()[0].val ()==-2);
+        std::remove(file_name.c_str()); //cleanup (CATCH2 should provide some sort of teardown function for this?)
+    }
+
 }
+
+
 


### PR DESCRIPTION
-The design need the behaviour of an array of polymorphic objects. If you try to do this using any pointers/new/delete then you fighting the language.  I have also tried to do this in the past.
-In ordfer to work with the language we must use new when creating sites, but those pointers cab be immediately deposited in a std::shared_pointer<SiteBase>.  This is a reference counted pointer  that does all the memory management for us.  AND we can copy them (or the whole array) at will.
-Tested for memory leaks with valgrind .. no leaks.
-Users adding new site types will have to virtually inheret from SiteBase. But I don't think they will need to directly deal with pointers. You can see and example of this in the sample/electronk.h
-I think we can set things up so that users can build arbitrary mixed site sets. again without using pointers directly.
-In the unit tests I added some examples of what can happen when writeing to file and reading back.  Right now you must know what SiteSet type you are reading back other wise chaos will ensue!  Again we can fix this using a factory pattern behind the scenes.
SiteSet refactoring proposal

Fix build in sample folder