### PR TITLE
Fix format conflict with `std::format`

### DIFF
--- a/itensor/index.cc
+++ b/itensor/index.cc
@@ -386,7 +386,7 @@ operator==(IndexVal const& iv, Index const& I)
     }
 
 string
-showDim(Index const& I) { return tfm::format("dim=%d",dim(I)); }
+showDim(Index const& I) { return tinyformat::format("dim=%d",dim(I)); }
 
 std::ostream& 
 operator<<(std::ostream& s, IndexVal const& iv)
@@ -407,7 +407,7 @@ TagSet
 getTagSet(Args       const& args, 
           Args::Name const& name)
     {
-    if(!args.defined(name)) Error(tfm::format("Name %s not found in Args",name));
+    if(!args.defined(name)) Error(tinyformat::format("Name %s not found in Args",name));
     return TagSet(args.getString(name));
     }
 
@@ -788,7 +788,7 @@ h5_write(h5::group parent, std::string const& name, Index const& I)
             for(auto n : range1(I.nblock()))
                 {
                 dims[n-1] = I.blocksize(n);
-                h5_write(qg,tfm::format("QN[%d]",n),I.qn(n));
+                h5_write(qg,tinyformat::format("QN[%d]",n),I.qn(n));
                 }
             h5_write(qg,"dims",dims);
             }
@@ -818,7 +818,7 @@ h5_read(h5::group parent, std::string const& name, Index & I)
         auto qns = vector<QNInt>(nblocks);
         for(auto n : range1(nblocks))
             {
-            auto qn = h5_read<QN>(qg,tfm::format("QN[%d]",n));
+            auto qn = h5_read<QN>(qg,tinyformat::format("QN[%d]",n));
             qns[n-1] = std::make_pair(qn,dims[n-1]);
             }
         I = Index(id,dim,toArrow(dir),tags,std::move(qns));

--- a/itensor/index.cc
+++ b/itensor/index.cc
@@ -386,7 +386,7 @@ operator==(IndexVal const& iv, Index const& I)
     }
 
 string
-showDim(Index const& I) { return format("dim=%d",dim(I)); }
+showDim(Index const& I) { return tfm::format("dim=%d",dim(I)); }
 
 std::ostream& 
 operator<<(std::ostream& s, IndexVal const& iv)
@@ -407,7 +407,7 @@ TagSet
 getTagSet(Args       const& args, 
           Args::Name const& name)
     {
-    if(!args.defined(name)) Error(format("Name %s not found in Args",name));
+    if(!args.defined(name)) Error(tfm::format("Name %s not found in Args",name));
     return TagSet(args.getString(name));
     }
 
@@ -788,7 +788,7 @@ h5_write(h5::group parent, std::string const& name, Index const& I)
             for(auto n : range1(I.nblock()))
                 {
                 dims[n-1] = I.blocksize(n);
-                h5_write(qg,format("QN[%d]",n),I.qn(n));
+                h5_write(qg,tfm::format("QN[%d]",n),I.qn(n));
                 }
             h5_write(qg,"dims",dims);
             }
@@ -818,7 +818,7 @@ h5_read(h5::group parent, std::string const& name, Index & I)
         auto qns = vector<QNInt>(nblocks);
         for(auto n : range1(nblocks))
             {
-            auto qn = h5_read<QN>(qg,format("QN[%d]",n));
+            auto qn = h5_read<QN>(qg,tfm::format("QN[%d]",n));
             qns[n-1] = std::make_pair(qn,dims[n-1]);
             }
         I = Index(id,dim,toArrow(dir),tags,std::move(qns));

--- a/itensor/indexset.cc
+++ b/itensor/indexset.cc
@@ -700,7 +700,7 @@ h5_write(h5::group parent, std::string const& name, IndexSet const& is)
     h5_write(g,"length",N);
     for(auto n : range1(N))
         {
-        auto iname = format("index_%d",n);
+        auto iname = tfm::format("index_%d",n);
         h5_write(g,iname,is(n));
         }
     }
@@ -716,7 +716,7 @@ h5_read(h5::group parent, std::string const& name, IndexSet & is)
     auto inds = IndexSetBuilder(N);
     for(auto n : range1(N))
         {
-        auto iname = format("index_%d",n);
+        auto iname = tfm::format("index_%d",n);
         auto i = h5_read<Index>(g,iname);
         inds.nextIndex(i);
         }

--- a/itensor/indexset.cc
+++ b/itensor/indexset.cc
@@ -700,7 +700,7 @@ h5_write(h5::group parent, std::string const& name, IndexSet const& is)
     h5_write(g,"length",N);
     for(auto n : range1(N))
         {
-        auto iname = tfm::format("index_%d",n);
+        auto iname = tinyformat::format("index_%d",n);
         h5_write(g,iname,is(n));
         }
     }
@@ -716,7 +716,7 @@ h5_read(h5::group parent, std::string const& name, IndexSet & is)
     auto inds = IndexSetBuilder(N);
     for(auto n : range1(N))
         {
-        auto iname = tfm::format("index_%d",n);
+        auto iname = tinyformat::format("index_%d",n);
         auto i = h5_read<Index>(g,iname);
         inds.nextIndex(i);
         }

--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -464,7 +464,7 @@ h5_read(h5::group parent, std::string const& name, Dense<V> & D)
     {
     auto g = parent.open_group(name);
     auto type = h5_read_attribute<string>(g,"type");
-    if(type != juliaTypeNameOf(D)) Error(format("Group does not contain %s data in HDF5 file",typeNameOf(D)));
+    if(type != juliaTypeNameOf(D)) Error(tfm::format("Group does not contain %s data in HDF5 file",typeNameOf(D)));
     auto data = h5_read<vector<V>>(g,"data");
     D = Dense<V>(move(data));
     }

--- a/itensor/itdata/dense.cc
+++ b/itensor/itdata/dense.cc
@@ -464,7 +464,7 @@ h5_read(h5::group parent, std::string const& name, Dense<V> & D)
     {
     auto g = parent.open_group(name);
     auto type = h5_read_attribute<string>(g,"type");
-    if(type != juliaTypeNameOf(D)) Error(tfm::format("Group does not contain %s data in HDF5 file",typeNameOf(D)));
+    if(type != juliaTypeNameOf(D)) Error(tinyformat::format("Group does not contain %s data in HDF5 file",typeNameOf(D)));
     auto data = h5_read<vector<V>>(g,"data");
     D = Dense<V>(move(data));
     }

--- a/itensor/itdata/diag.cc
+++ b/itensor/itdata/diag.cc
@@ -373,7 +373,7 @@ void
 doTask(PrintIT& P, Diag<T> const& d)
     {
     auto type = std::is_same<T,Real>::value ? "Real" : "Cplx";
-    P.printInfo(d,format("Diag %s%s",type,d.allSame()?", all same":""),
+    P.printInfo(d,tfm::format("Diag %s%s",type,d.allSame()?", all same":""),
               doTask(NormNoScale{},d));
 
     auto r = P.is.order();

--- a/itensor/itdata/diag.cc
+++ b/itensor/itdata/diag.cc
@@ -373,7 +373,7 @@ void
 doTask(PrintIT& P, Diag<T> const& d)
     {
     auto type = std::is_same<T,Real>::value ? "Real" : "Cplx";
-    P.printInfo(d,tfm::format("Diag %s%s",type,d.allSame()?", all same":""),
+    P.printInfo(d,tinyformat::format("Diag %s%s",type,d.allSame()?", all same":""),
               doTask(NormNoScale{},d));
 
     auto r = P.is.order();

--- a/itensor/itdata/dotask.h
+++ b/itensor/itdata/dotask.h
@@ -254,7 +254,7 @@ callDoTask_Impl(stdx::choice<3>, Task& t, D1& d1, const D2& d2, ManageStore& m, 
     auto tname = typeNameOf(t);
     auto d1name = typeNameOf(d1);
     auto d2name = typeNameOf(d2);
-    throw ITError(format("2 parameter doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
+    throw ITError(tfm::format("2 parameter doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
     //throw ITError("2 parameter doTask not defined for specified task or data type [2]");
     }
 template <typename Ret, typename Task, typename D1, typename D2>
@@ -533,7 +533,7 @@ call(RT& rt, Task& t, D& d, ManageStore& m, Return& ret)
         {
         auto tname = typeNameOf(t);
         auto dname = typeNameOf(d);
-        throw ITError(format("doTask not defined for task %s and storage type %s",tname,dname));
+        throw ITError(tfm::format("doTask not defined for task %s and storage type %s",tname,dname));
         }
     }
 
@@ -621,7 +621,7 @@ applyToImpl(D2& d2)
         auto tname = typeNameOf(t_);
         auto d1name = typeNameOf(d1_);
         auto d2name = typeNameOf(d2);
-        throw ITError(format("doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
+        throw ITError(tfm::format("doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
         }
     }
 

--- a/itensor/itdata/dotask.h
+++ b/itensor/itdata/dotask.h
@@ -254,7 +254,7 @@ callDoTask_Impl(stdx::choice<3>, Task& t, D1& d1, const D2& d2, ManageStore& m, 
     auto tname = typeNameOf(t);
     auto d1name = typeNameOf(d1);
     auto d2name = typeNameOf(d2);
-    throw ITError(tfm::format("2 parameter doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
+    throw ITError(tinyformat::format("2 parameter doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
     //throw ITError("2 parameter doTask not defined for specified task or data type [2]");
     }
 template <typename Ret, typename Task, typename D1, typename D2>
@@ -533,7 +533,7 @@ call(RT& rt, Task& t, D& d, ManageStore& m, Return& ret)
         {
         auto tname = typeNameOf(t);
         auto dname = typeNameOf(d);
-        throw ITError(tfm::format("doTask not defined for task %s and storage type %s",tname,dname));
+        throw ITError(tinyformat::format("doTask not defined for task %s and storage type %s",tname,dname));
         }
     }
 
@@ -621,7 +621,7 @@ applyToImpl(D2& d2)
         auto tname = typeNameOf(t_);
         auto d1name = typeNameOf(d1_);
         auto d2name = typeNameOf(d2);
-        throw ITError(tfm::format("doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
+        throw ITError(tinyformat::format("doTask not defined for task %s and storage types %s %s",tname,d1name,d2name));
         }
     }
 

--- a/itensor/itdata/qdense.cc
+++ b/itensor/itdata/qdense.cc
@@ -420,14 +420,14 @@ template<typename T>
 void
 doTask(PrintIT& P, QDense<T> const& d)
     {
-    auto name = tfm::format("QDense %s",typeName<T>());
+    auto name = tinyformat::format("QDense %s",typeName<T>());
     if(not P.print_data)
         {
         P.printInfo(d,name,doTask(NormNoScale{},d));
         return;
         }
 
-    P.s << tfm::format("QDense %s {%d blocks; data size %d}\n",
+    P.s << tinyformat::format("QDense %s {%d blocks; data size %d}\n",
                   typeName<T>(),d.offsets.size(),d.size());
     //Real scalefac = 1.0;
     //if(!P.x.isTooBigForReal()) scalefac = P.x.real0();
@@ -1057,7 +1057,7 @@ h5_read(h5::group parent, std::string const& name, QDense<V> & D)
     auto type = h5_read_attribute<string>(g,"type");
     if(type != juliaTypeNameOf(D)) 
         {
-        Error(tfm::format("Group does not contain %s or %s data in HDF5 file",typeNameOf(D),juliaTypeNameOf(D)));
+        Error(tinyformat::format("Group does not contain %s or %s data in HDF5 file",typeNameOf(D),juliaTypeNameOf(D)));
         }
     auto N = h5_read<long>(g,"ndims");
     auto off_array = offsets_to_array(D.offsets,N);

--- a/itensor/itdata/qdense.cc
+++ b/itensor/itdata/qdense.cc
@@ -420,14 +420,14 @@ template<typename T>
 void
 doTask(PrintIT& P, QDense<T> const& d)
     {
-    auto name = format("QDense %s",typeName<T>());
+    auto name = tfm::format("QDense %s",typeName<T>());
     if(not P.print_data)
         {
         P.printInfo(d,name,doTask(NormNoScale{},d));
         return;
         }
 
-    P.s << format("QDense %s {%d blocks; data size %d}\n",
+    P.s << tfm::format("QDense %s {%d blocks; data size %d}\n",
                   typeName<T>(),d.offsets.size(),d.size());
     //Real scalefac = 1.0;
     //if(!P.x.isTooBigForReal()) scalefac = P.x.real0();
@@ -1057,7 +1057,7 @@ h5_read(h5::group parent, std::string const& name, QDense<V> & D)
     auto type = h5_read_attribute<string>(g,"type");
     if(type != juliaTypeNameOf(D)) 
         {
-        Error(format("Group does not contain %s or %s data in HDF5 file",typeNameOf(D),juliaTypeNameOf(D)));
+        Error(tfm::format("Group does not contain %s or %s data in HDF5 file",typeNameOf(D),juliaTypeNameOf(D)));
         }
     auto N = h5_read<long>(g,"ndims");
     auto off_array = offsets_to_array(D.offsets,N);

--- a/itensor/itdata/qdiag.cc
+++ b/itensor/itdata/qdiag.cc
@@ -280,7 +280,7 @@ template<typename T>
 void
 doTask(PrintIT& P, QDiag<T> const& d)
     {
-    P.s << format("QDiag%s%s\n",typeName<T>(),d.allSame()?" (all same)":"");
+    P.s << tfm::format("QDiag%s%s\n",typeName<T>(),d.allSame()?" (all same)":"");
     Real scalefac = 1.0;
     if(!P.x.isTooBigForReal()) scalefac = P.x.real0();
     else P.s << "(omitting too large scale factor)\n";

--- a/itensor/itdata/qdiag.cc
+++ b/itensor/itdata/qdiag.cc
@@ -280,7 +280,7 @@ template<typename T>
 void
 doTask(PrintIT& P, QDiag<T> const& d)
     {
-    P.s << tfm::format("QDiag%s%s\n",typeName<T>(),d.allSame()?" (all same)":"");
+    P.s << tinyformat::format("QDiag%s%s\n",typeName<T>(),d.allSame()?" (all same)":"");
     Real scalefac = 1.0;
     if(!P.x.isTooBigForReal()) scalefac = P.x.real0();
     else P.s << "(omitting too large scale factor)\n";

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -102,14 +102,14 @@ struct PrintIT
               Real nrm_no_scale = -1)
         {
 #ifndef USESCALE
-        s << tfm::format("{norm=%.2f (%s)}\n",std::fabs(scalefac)*nrm_no_scale,type_name);
+        s << tinyformat::format("{norm=%.2f (%s)}\n",std::fabs(scalefac)*nrm_no_scale,type_name);
 #else
-        s << "{log(scale)=" << tfm::format("%.2f",x.logNum());
+        s << "{log(scale)=" << tinyformat::format("%.2f",x.logNum());
         if(nrm_no_scale > 0)
             {
             if(!x.isTooBigForReal()) s << ", norm=";
             else  s << ", norm(omitting large scale)=";
-            s << tfm::format("%.2f",std::fabs(scalefac)*nrm_no_scale);
+            s << tinyformat::format("%.2f",std::fabs(scalefac)*nrm_no_scale);
             }
         s << " (" << type_name << ")}\n";
 #endif
@@ -166,7 +166,7 @@ struct ApplyIT
     void
     applyITImpl(stdx::choice<2>,T1, T2 &)
         {
-        auto msg = tfm::format("Apply: function doesn't map %s->%s",typeName<T1>(),typeName<T2>());
+        auto msg = tinyformat::format("Apply: function doesn't map %s->%s",typeName<T1>(),typeName<T2>());
         Error(msg);
         }
     template<typename T1, typename T2>
@@ -507,7 +507,7 @@ checkEltInd(IndexSet const& is,
             print("inds = ");
             for(auto j : inds) print(1+j," ");
             println();
-            Error(tfm::format("Out of range: IndexVal at position %d has val %d > %s",1+k,1+i,Index(is[k])));
+            Error(tinyformat::format("Out of range: IndexVal at position %d has val %d > %s",1+k,1+i,Index(is[k])));
             }
         }
     }

--- a/itensor/itdata/task_types.h
+++ b/itensor/itdata/task_types.h
@@ -102,14 +102,14 @@ struct PrintIT
               Real nrm_no_scale = -1)
         {
 #ifndef USESCALE
-        s << format("{norm=%.2f (%s)}\n",std::fabs(scalefac)*nrm_no_scale,type_name);
+        s << tfm::format("{norm=%.2f (%s)}\n",std::fabs(scalefac)*nrm_no_scale,type_name);
 #else
-        s << "{log(scale)=" << format("%.2f",x.logNum());
+        s << "{log(scale)=" << tfm::format("%.2f",x.logNum());
         if(nrm_no_scale > 0)
             {
             if(!x.isTooBigForReal()) s << ", norm=";
             else  s << ", norm(omitting large scale)=";
-            s << format("%.2f",std::fabs(scalefac)*nrm_no_scale);
+            s << tfm::format("%.2f",std::fabs(scalefac)*nrm_no_scale);
             }
         s << " (" << type_name << ")}\n";
 #endif
@@ -166,7 +166,7 @@ struct ApplyIT
     void
     applyITImpl(stdx::choice<2>,T1, T2 &)
         {
-        auto msg = format("Apply: function doesn't map %s->%s",typeName<T1>(),typeName<T2>());
+        auto msg = tfm::format("Apply: function doesn't map %s->%s",typeName<T1>(),typeName<T2>());
         Error(msg);
         }
     template<typename T1, typename T2>
@@ -507,7 +507,7 @@ checkEltInd(IndexSet const& is,
             print("inds = ");
             for(auto j : inds) print(1+j," ");
             println();
-            Error(format("Out of range: IndexVal at position %d has val %d > %s",1+k,1+i,Index(is[k])));
+            Error(tfm::format("Out of range: IndexVal at position %d has val %d > %s",1+k,1+i,Index(is[k])));
             }
         }
     }

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -86,7 +86,7 @@ eltC() const
     if(inds().order() != 0)
         {
         PrintData(inds());
-        Error(format("Wrong number of IndexVals passed to elt/eltC (expected 0, got %d)",inds().order()));
+        Error(tfm::format("Wrong number of IndexVals passed to elt/eltC (expected 0, got %d)",inds().order()));
         }
     constexpr size_t size = 0;
     auto inds = IntArray(size);
@@ -125,7 +125,7 @@ eltC(std::vector<IndexVal> const& ivs) const
         println("Indices provided = ");
         for(auto& iv : ivs) println(iv.index);
         println("---------------------------------------------");
-        Error(format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",inds().order(),size));
+        Error(tfm::format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",inds().order(),size));
         }
 
     auto ints = IntArray(size);
@@ -167,7 +167,7 @@ set(std::vector<IndexVal> const& ivals,
         println("Indices provided = ");
         for(auto& iv : ivals) println(iv.index);
         println("---------------------------------------------");
-        Error(format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     auto inds = IntArray(is_.order(),0);
@@ -190,7 +190,7 @@ set(Cplx val)
     {
     if(0 != size_t(inds().order())) 
         {
-        Error(format("Wrong number of IndexVals passed to set (expected %d, got 0)",
+        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got 0)",
                      inds().order()));
         }
     auto inds = IntArray(0,1);
@@ -219,7 +219,7 @@ set(std::vector<int> const& ints,
         println("Indices provided = ");
         for(auto& iv : ints) println(iv);
         println("---------------------------------------------");
-        Error(format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     auto inds = IntArray(is_.order(),0);
@@ -640,7 +640,7 @@ permute(IndexSet const& iset)
         println("---------------------------------------------");
         println("Indices provided = \n",iset,"\n");
         println("---------------------------------------------");
-        Error(format("Wrong number of Indexes passed to permute (expected %d, got %d)",r,iset.order()));
+        Error(tfm::format("Wrong number of Indexes passed to permute (expected %d, got %d)",r,iset.order()));
         }
 
     // Get permutation
@@ -843,7 +843,7 @@ h5_read(h5::group parent, std::string const& name, ITensor & I)
     else if(s_type == "Dense{ComplexF64}") store = h5_readStore<DenseCplx>(g,store_name); 
     else if(s_type == "BlockSparse{Float64}") store = h5_readStore<QDenseReal>(g,store_name); 
     else if(s_type == "BlockSparse{ComplexF64}") store = h5_readStore<QDenseCplx>(g,store_name); 
-    else error(format("Reading of ITensor storage type %s not yet supported",s_type));
+    else error(tfm::format("Reading of ITensor storage type %s not yet supported",s_type));
 
     I = ITensor(is,std::move(store));
     }
@@ -924,7 +924,7 @@ checkSameDiv(ITensor const& T1,
         {
         if(div(T1) != div(T2)) 
             {
-            Error(format("div(T1)=%s must equal div(T2)=%s when adding T1+T2",div(T1),div(T2)));
+            Error(tfm::format("div(T1)=%s must equal div(T2)=%s when adding T1+T2",div(T1),div(T2)));
             }
         }
     }
@@ -1670,7 +1670,7 @@ moveToFront(IndexSet const& isf, IndexSet const& is)
         println("---------------------------------------------");
         println("Indices provided = \n",isf," '...'\n");
         println("---------------------------------------------");
-        Error(format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rf));
+        Error(tfm::format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rf));
         }
 
     auto iso = IndexSet(r);
@@ -1685,7 +1685,7 @@ moveToFront(IndexSet const& isf, IndexSet const& is)
             println("---------------------------------------------");
             println("Indices provided = \n",isf," '...'\n");
             println("---------------------------------------------");
-            Error(format("Bad index passed to permute"));
+            Error(tfm::format("Bad index passed to permute"));
             }
         iso[i] = I;
         i++;
@@ -1717,7 +1717,7 @@ moveToBack(IndexSet const& isb, IndexSet const& is)
         println("---------------------------------------------");
         println("Indices provided = \n'...' ",isb,"\n");
         println("---------------------------------------------");
-        Error(format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rb));
+        Error(tfm::format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rb));
         }
 
     auto iso = IndexSet(r);
@@ -1732,7 +1732,7 @@ moveToBack(IndexSet const& isb, IndexSet const& is)
             println("---------------------------------------------");
             println("Indices provided = \n'...' ",isb,"\n");
             println("---------------------------------------------");
-            Error(format("Bad index passed to permute"));
+            Error(tfm::format("Bad index passed to permute"));
             }
         iso[i] = I;
         i++;

--- a/itensor/itensor.cc
+++ b/itensor/itensor.cc
@@ -86,7 +86,7 @@ eltC() const
     if(inds().order() != 0)
         {
         PrintData(inds());
-        Error(tfm::format("Wrong number of IndexVals passed to elt/eltC (expected 0, got %d)",inds().order()));
+        Error(tinyformat::format("Wrong number of IndexVals passed to elt/eltC (expected 0, got %d)",inds().order()));
         }
     constexpr size_t size = 0;
     auto inds = IntArray(size);
@@ -125,7 +125,7 @@ eltC(std::vector<IndexVal> const& ivs) const
         println("Indices provided = ");
         for(auto& iv : ivs) println(iv.index);
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",inds().order(),size));
+        Error(tinyformat::format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",inds().order(),size));
         }
 
     auto ints = IntArray(size);
@@ -167,7 +167,7 @@ set(std::vector<IndexVal> const& ivals,
         println("Indices provided = ");
         for(auto& iv : ivals) println(iv.index);
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+        Error(tinyformat::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     auto inds = IntArray(is_.order(),0);
@@ -190,7 +190,7 @@ set(Cplx val)
     {
     if(0 != size_t(inds().order())) 
         {
-        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got 0)",
+        Error(tinyformat::format("Wrong number of IndexVals passed to set (expected %d, got 0)",
                      inds().order()));
         }
     auto inds = IntArray(0,1);
@@ -219,7 +219,7 @@ set(std::vector<int> const& ints,
         println("Indices provided = ");
         for(auto& iv : ints) println(iv);
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+        Error(tinyformat::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     auto inds = IntArray(is_.order(),0);
@@ -640,7 +640,7 @@ permute(IndexSet const& iset)
         println("---------------------------------------------");
         println("Indices provided = \n",iset,"\n");
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of Indexes passed to permute (expected %d, got %d)",r,iset.order()));
+        Error(tinyformat::format("Wrong number of Indexes passed to permute (expected %d, got %d)",r,iset.order()));
         }
 
     // Get permutation
@@ -843,7 +843,7 @@ h5_read(h5::group parent, std::string const& name, ITensor & I)
     else if(s_type == "Dense{ComplexF64}") store = h5_readStore<DenseCplx>(g,store_name); 
     else if(s_type == "BlockSparse{Float64}") store = h5_readStore<QDenseReal>(g,store_name); 
     else if(s_type == "BlockSparse{ComplexF64}") store = h5_readStore<QDenseCplx>(g,store_name); 
-    else error(tfm::format("Reading of ITensor storage type %s not yet supported",s_type));
+    else error(tinyformat::format("Reading of ITensor storage type %s not yet supported",s_type));
 
     I = ITensor(is,std::move(store));
     }
@@ -924,7 +924,7 @@ checkSameDiv(ITensor const& T1,
         {
         if(div(T1) != div(T2)) 
             {
-            Error(tfm::format("div(T1)=%s must equal div(T2)=%s when adding T1+T2",div(T1),div(T2)));
+            Error(tinyformat::format("div(T1)=%s must equal div(T2)=%s when adding T1+T2",div(T1),div(T2)));
             }
         }
     }
@@ -1670,7 +1670,7 @@ moveToFront(IndexSet const& isf, IndexSet const& is)
         println("---------------------------------------------");
         println("Indices provided = \n",isf," '...'\n");
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rf));
+        Error(tinyformat::format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rf));
         }
 
     auto iso = IndexSet(r);
@@ -1685,7 +1685,7 @@ moveToFront(IndexSet const& isf, IndexSet const& is)
             println("---------------------------------------------");
             println("Indices provided = \n",isf," '...'\n");
             println("---------------------------------------------");
-            Error(tfm::format("Bad index passed to permute"));
+            Error(tinyformat::format("Bad index passed to permute"));
             }
         iso[i] = I;
         i++;
@@ -1717,7 +1717,7 @@ moveToBack(IndexSet const& isb, IndexSet const& is)
         println("---------------------------------------------");
         println("Indices provided = \n'...' ",isb,"\n");
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rb));
+        Error(tinyformat::format("Wrong number of indices passed to permute (expected < %d, got %d)",r,rb));
         }
 
     auto iso = IndexSet(r);
@@ -1732,7 +1732,7 @@ moveToBack(IndexSet const& isb, IndexSet const& is)
             println("---------------------------------------------");
             println("Indices provided = \n'...' ",isb,"\n");
             println("---------------------------------------------");
-            Error(tfm::format("Bad index passed to permute"));
+            Error(tinyformat::format("Bad index passed to permute"));
             }
         iso[i] = I;
         i++;

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -85,7 +85,7 @@ eltC(IV const& iv1, IVs&&... ivs) const
         println("Indices provided = ");
         for(auto& iv : vals) println(iv.index);
         println("---------------------------------------------");
-        Error(format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",
+        Error(tfm::format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",
                      inds().order(),size));
         }
 
@@ -130,7 +130,7 @@ eltC(std::vector<Int> const& ints) const
         print("Indices provided = ");
         for(auto i : ints) print(" ",i);
         println("\n---------------------------------------------");
-        Error(format("Wrong number of ints passed to elt/eltC (expected %d, got %d)",
+        Error(tfm::format("Wrong number of ints passed to elt/eltC (expected %d, got %d)",
                      inds().order(),size));
         }
 
@@ -350,7 +350,7 @@ set(IV const& iv1, VArgs&&... vargs)
         println("Indices provided = ");
         for(auto& iv : vals) println(iv.index);
         println("---------------------------------------------");
-        Error(format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     auto inds = IntArray(is_.order(),0);
@@ -389,7 +389,7 @@ set(Int iv1, VArgs&&... vargs)
         for(auto& i : ints) print(" ",1+i);
         println();
         println("---------------------------------------------");
-        Error(format("Wrong number of ints passed to set (expected %d, got %d)",
+        Error(tfm::format("Wrong number of ints passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     //TODO: if !store_ and !is_real, call allocCplx instead

--- a/itensor/itensor_impl.h
+++ b/itensor/itensor_impl.h
@@ -85,7 +85,7 @@ eltC(IV const& iv1, IVs&&... ivs) const
         println("Indices provided = ");
         for(auto& iv : vals) println(iv.index);
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",
+        Error(tinyformat::format("Wrong number of IndexVals passed to elt/eltC (expected %d, got %d)",
                      inds().order(),size));
         }
 
@@ -130,7 +130,7 @@ eltC(std::vector<Int> const& ints) const
         print("Indices provided = ");
         for(auto i : ints) print(" ",i);
         println("\n---------------------------------------------");
-        Error(tfm::format("Wrong number of ints passed to elt/eltC (expected %d, got %d)",
+        Error(tinyformat::format("Wrong number of ints passed to elt/eltC (expected %d, got %d)",
                      inds().order(),size));
         }
 
@@ -350,7 +350,7 @@ set(IV const& iv1, VArgs&&... vargs)
         println("Indices provided = ");
         for(auto& iv : vals) println(iv.index);
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
+        Error(tinyformat::format("Wrong number of IndexVals passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     auto inds = IntArray(is_.order(),0);
@@ -389,7 +389,7 @@ set(Int iv1, VArgs&&... vargs)
         for(auto& i : ints) print(" ",1+i);
         println();
         println("---------------------------------------------");
-        Error(tfm::format("Wrong number of ints passed to set (expected %d, got %d)",
+        Error(tinyformat::format("Wrong number of ints passed to set (expected %d, got %d)",
                      inds().order(),size));
         }
     //TODO: if !store_ and !is_real, call allocCplx instead

--- a/itensor/mps/DMRGObserver.h
+++ b/itensor/mps/DMRGObserver.h
@@ -159,8 +159,8 @@ measure(Args const& args)
         if(b == 1 && ha == 2) 
             {
             if(!printeigs) println();
-            auto swstr = (nsweep>0) ? format("%d/%d",sw,nsweep) 
-                                    : format("%d",sw);
+            auto swstr = (nsweep>0) ? tfm::format("%d/%d",sw,nsweep) 
+                                    : tfm::format("%d",sw);
             println("    Largest link dim during sweep ",swstr," was ",(max_eigs > 1 ? max_eigs : 1));
             max_eigs = -1;
             println("    Largest truncation error: ",(max_te > 0 ? max_te : 0.));

--- a/itensor/mps/DMRGObserver.h
+++ b/itensor/mps/DMRGObserver.h
@@ -159,8 +159,8 @@ measure(Args const& args)
         if(b == 1 && ha == 2) 
             {
             if(!printeigs) println();
-            auto swstr = (nsweep>0) ? tfm::format("%d/%d",sw,nsweep) 
-                                    : tfm::format("%d",sw);
+            auto swstr = (nsweep>0) ? tinyformat::format("%d/%d",sw,nsweep) 
+                                    : tinyformat::format("%d",sw);
             println("    Largest link dim during sweep ",swstr," was ",(max_eigs > 1 ? max_eigs : 1));
             max_eigs = -1;
             println("    Largest truncation error: ",(max_te > 0 ? max_te : 0.));

--- a/itensor/mps/autompo.cc
+++ b/itensor/mps/autompo.cc
@@ -645,7 +645,7 @@ toMPOImpl(AutoMPO const& am,
             }
         inqn.emplace_back(currq,currm);
 
-        links.at(n) = Index(move(inqn),format("Link,l=%d",n));
+        links.at(n) = Index(move(inqn),tfm::format("Link,l=%d",n));
         //printfln("links[%d]=\n%s",n,links[n]);
 
         //if(n <= 2 or n == N)
@@ -735,7 +735,7 @@ toMPOImpl(AutoMPO const& am,
                             {
                             found += 1;
 #ifdef SHOW_AUTOMPO
-                            ws[r][c] = format("%.2f %s",st.coef,st.op);
+                            ws[r][c] = tfm::format("%.2f %s",st.coef,st.op);
 #endif
                             W += st.coef * op(sites,st.op,n) * rc;
                             }
@@ -777,11 +777,11 @@ toMPOImpl(AutoMPO const& am,
                     auto coef = ht.coef;
                     if(isApproxReal(coef))
                         {
-                        ws[r][c] = format("%.2f %s",coef.real(),op);
+                        ws[r][c] = tfm::format("%.2f %s",coef.real(),op);
                         }
                     else
                         {
-                        ws[r][c] = format("%.2f %s",coef,op);
+                        ws[r][c] = tfm::format("%.2f %s",coef,op);
                         }
 #endif
                     }
@@ -795,9 +795,9 @@ toMPOImpl(AutoMPO const& am,
                     {
 #ifdef SHOW_AUTOMPO
                     if(isApproxReal(ht.first().coef))
-                        ws[r][c] = format("%.2f %s",ht.coef.real(),ht.first().op);
+                        ws[r][c] = tfm::format("%.2f %s",ht.coef.real(),ht.first().op);
                     else
-                        ws[r][c] = format("%.2f %s",ht.coef,ht.first().op);
+                        ws[r][c] = tfm::format("%.2f %s",ht.coef,ht.first().op);
 #endif
                     W += ht.coef * convert_tensor(op(sites,ht.first().op,n)) * rc;
                     }
@@ -1190,8 +1190,8 @@ compressMPO(SiteSet const& sites,
     int d0 = isExpH ? 1 : 2;
     
     //TODO: check these are the correct tags
-    if(hasqn) links.at(0) = Index(ZeroQN,d0,format("Link,l=%d",0));
-    else      links.at(0) = Index(d0,format("Link,l=%d",0));
+    if(hasqn) links.at(0) = Index(ZeroQN,d0,tfm::format("Link,l=%d",0));
+    else      links.at(0) = Index(d0,tfm::format("Link,l=%d",0));
 
     auto max_d = dim(links.at(0));
     for(int n = 1; n <= N; ++n)
@@ -1239,7 +1239,7 @@ compressMPO(SiteSet const& sites,
                 int m = ncols(V_npp[q]);
                 inqn.emplace_back(q,m);
                 }
-            links.at(n) = Index(move(inqn),format("Link,l=%d",n));
+            links.at(n) = Index(move(inqn),tfm::format("Link,l=%d",n));
             }
         else
             {
@@ -1250,7 +1250,7 @@ compressMPO(SiteSet const& sites,
                 if(q == ZeroQN) continue; // was already taken care of
                 m += ncols(V_npp[q]);
                 }
-            links.at(n) = Index(m,format("Link,l=%d",n));
+            links.at(n) = Index(m,tfm::format("Link,l=%d",n));
             }
 
         //
@@ -1586,7 +1586,7 @@ toExpH_ZW1(AutoMPO const& am,
             }
         qnsize.emplace_back(currq,currm);
 
-        links.at(n) = Index(move(qnsize),format("Link,l=%d",n));
+        links.at(n) = Index(move(qnsize),tfm::format("Link,l=%d",n));
 
         //if(n <= 2 or n == N)
         //    {
@@ -1696,7 +1696,7 @@ toExpH(AutoMPO const& a,
         }
     else
         {
-        Error(format("Unknown approximation Approx=\"%s\"",approx));
+        Error(tfm::format("Unknown approximation Approx=\"%s\"",approx));
         }
     return res;
     }
@@ -1715,11 +1715,11 @@ operator<<(std::ostream& s, HTerm const& t)
     const char* pfix = "";
     if(abs(t.coef-1.0) > 1E-12) 
         {
-        s << (isReal(t.coef) ? format("%f ",t.coef.real()) : format("%f ",t.coef));
+        s << (isReal(t.coef) ? tfm::format("%f ",t.coef.real()) : tfm::format("%f ",t.coef));
         }
     for(auto& st : t.ops) 
         {
-        s << format("%s%s(%d)",pfix,st.op,st.i);
+        s << tfm::format("%s%s(%d)",pfix,st.op,st.i);
         pfix = " ";
         }
     return s;

--- a/itensor/mps/autompo.cc
+++ b/itensor/mps/autompo.cc
@@ -645,7 +645,7 @@ toMPOImpl(AutoMPO const& am,
             }
         inqn.emplace_back(currq,currm);
 
-        links.at(n) = Index(move(inqn),tfm::format("Link,l=%d",n));
+        links.at(n) = Index(move(inqn),tinyformat::format("Link,l=%d",n));
         //printfln("links[%d]=\n%s",n,links[n]);
 
         //if(n <= 2 or n == N)
@@ -735,7 +735,7 @@ toMPOImpl(AutoMPO const& am,
                             {
                             found += 1;
 #ifdef SHOW_AUTOMPO
-                            ws[r][c] = tfm::format("%.2f %s",st.coef,st.op);
+                            ws[r][c] = tinyformat::format("%.2f %s",st.coef,st.op);
 #endif
                             W += st.coef * op(sites,st.op,n) * rc;
                             }
@@ -777,11 +777,11 @@ toMPOImpl(AutoMPO const& am,
                     auto coef = ht.coef;
                     if(isApproxReal(coef))
                         {
-                        ws[r][c] = tfm::format("%.2f %s",coef.real(),op);
+                        ws[r][c] = tinyformat::format("%.2f %s",coef.real(),op);
                         }
                     else
                         {
-                        ws[r][c] = tfm::format("%.2f %s",coef,op);
+                        ws[r][c] = tinyformat::format("%.2f %s",coef,op);
                         }
 #endif
                     }
@@ -795,9 +795,9 @@ toMPOImpl(AutoMPO const& am,
                     {
 #ifdef SHOW_AUTOMPO
                     if(isApproxReal(ht.first().coef))
-                        ws[r][c] = tfm::format("%.2f %s",ht.coef.real(),ht.first().op);
+                        ws[r][c] = tinyformat::format("%.2f %s",ht.coef.real(),ht.first().op);
                     else
-                        ws[r][c] = tfm::format("%.2f %s",ht.coef,ht.first().op);
+                        ws[r][c] = tinyformat::format("%.2f %s",ht.coef,ht.first().op);
 #endif
                     W += ht.coef * convert_tensor(op(sites,ht.first().op,n)) * rc;
                     }
@@ -1190,8 +1190,8 @@ compressMPO(SiteSet const& sites,
     int d0 = isExpH ? 1 : 2;
     
     //TODO: check these are the correct tags
-    if(hasqn) links.at(0) = Index(ZeroQN,d0,tfm::format("Link,l=%d",0));
-    else      links.at(0) = Index(d0,tfm::format("Link,l=%d",0));
+    if(hasqn) links.at(0) = Index(ZeroQN,d0,tinyformat::format("Link,l=%d",0));
+    else      links.at(0) = Index(d0,tinyformat::format("Link,l=%d",0));
 
     auto max_d = dim(links.at(0));
     for(int n = 1; n <= N; ++n)
@@ -1239,7 +1239,7 @@ compressMPO(SiteSet const& sites,
                 int m = ncols(V_npp[q]);
                 inqn.emplace_back(q,m);
                 }
-            links.at(n) = Index(move(inqn),tfm::format("Link,l=%d",n));
+            links.at(n) = Index(move(inqn),tinyformat::format("Link,l=%d",n));
             }
         else
             {
@@ -1250,7 +1250,7 @@ compressMPO(SiteSet const& sites,
                 if(q == ZeroQN) continue; // was already taken care of
                 m += ncols(V_npp[q]);
                 }
-            links.at(n) = Index(m,tfm::format("Link,l=%d",n));
+            links.at(n) = Index(m,tinyformat::format("Link,l=%d",n));
             }
 
         //
@@ -1586,7 +1586,7 @@ toExpH_ZW1(AutoMPO const& am,
             }
         qnsize.emplace_back(currq,currm);
 
-        links.at(n) = Index(move(qnsize),tfm::format("Link,l=%d",n));
+        links.at(n) = Index(move(qnsize),tinyformat::format("Link,l=%d",n));
 
         //if(n <= 2 or n == N)
         //    {
@@ -1696,7 +1696,7 @@ toExpH(AutoMPO const& a,
         }
     else
         {
-        Error(tfm::format("Unknown approximation Approx=\"%s\"",approx));
+        Error(tinyformat::format("Unknown approximation Approx=\"%s\"",approx));
         }
     return res;
     }
@@ -1715,11 +1715,11 @@ operator<<(std::ostream& s, HTerm const& t)
     const char* pfix = "";
     if(abs(t.coef-1.0) > 1E-12) 
         {
-        s << (isReal(t.coef) ? tfm::format("%f ",t.coef.real()) : tfm::format("%f ",t.coef));
+        s << (isReal(t.coef) ? tinyformat::format("%f ",t.coef.real()) : tinyformat::format("%f ",t.coef));
         }
     for(auto& st : t.ops) 
         {
-        s << tfm::format("%s%s(%d)",pfix,st.op,st.i);
+        s << tinyformat::format("%s%s(%d)",pfix,st.op,st.i);
         pfix = " ";
         }
     return s;

--- a/itensor/mps/lattice/latticebond.h
+++ b/itensor/mps/lattice/latticebond.h
@@ -76,16 +76,16 @@ struct LatticeBond
 inline std::ostream& 
 operator<<(std::ostream & s, LatticeBond const& b) 
     { 
-    //s << tfm::format("(%*d,%*d",3,b.s1,3,b.s2);
-    s << tfm::format("(%d,%d",b.s1,b.s2);
+    //s << tinyformat::format("(%*d,%*d",3,b.s1,3,b.s2);
+    s << tinyformat::format("(%d,%d",b.s1,b.s2);
     if(b.type.size()!=0) s << "," << b.type;
     s << ")";
     if(!std::isnan(b.x1) && !std::isnan(b.y1))
         {
-        s << tfm::format("[%s,%s",b.x1,b.y1);
+        s << tinyformat::format("[%s,%s",b.x1,b.y1);
         if(!std::isnan(b.x2) && !std::isnan(b.y2))
             {
-            s << tfm::format(";%s,%s]",b.x2,b.y2);
+            s << tinyformat::format(";%s,%s]",b.x2,b.y2);
             }
         else
             {

--- a/itensor/mps/lattice/latticebond.h
+++ b/itensor/mps/lattice/latticebond.h
@@ -76,16 +76,16 @@ struct LatticeBond
 inline std::ostream& 
 operator<<(std::ostream & s, LatticeBond const& b) 
     { 
-    //s << format("(%*d,%*d",3,b.s1,3,b.s2);
-    s << format("(%d,%d",b.s1,b.s2);
+    //s << tfm::format("(%*d,%*d",3,b.s1,3,b.s2);
+    s << tfm::format("(%d,%d",b.s1,b.s2);
     if(b.type.size()!=0) s << "," << b.type;
     s << ")";
     if(!std::isnan(b.x1) && !std::isnan(b.y1))
         {
-        s << format("[%s,%s",b.x1,b.y1);
+        s << tfm::format("[%s,%s",b.x1,b.y1);
         if(!std::isnan(b.x2) && !std::isnan(b.y2))
             {
-            s << format(";%s,%s]",b.x2,b.y2);
+            s << tfm::format(";%s,%s]",b.x2,b.y2);
             }
         else
             {

--- a/itensor/mps/localmpo.h
+++ b/itensor/mps/localmpo.h
@@ -258,7 +258,7 @@ class LocalMPO
     std::string
     PHFName(int j) const
         {
-        return format("%s/PH_%03d",writedir_,j);
+        return tfm::format("%s/PH_%03d",writedir_,j);
         }
 
     };

--- a/itensor/mps/localmpo.h
+++ b/itensor/mps/localmpo.h
@@ -258,7 +258,7 @@ class LocalMPO
     std::string
     PHFName(int j) const
         {
-        return tfm::format("%s/PH_%03d",writedir_,j);
+        return tinyformat::format("%s/PH_%03d",writedir_,j);
         }
 
     };

--- a/itensor/mps/mpo.cc
+++ b/itensor/mps/mpo.cc
@@ -976,7 +976,7 @@ h5_write(h5::group parent, string const& name, MPO const& M)
     h5_write(g,"llim",long(M.leftLim()));
     for(auto n : range1(M.length()))
         {
-        h5_write(g,tfm::format("MPO[%d]",n),M(n));
+        h5_write(g,tinyformat::format("MPO[%d]",n),M(n));
         }
     }
 
@@ -992,7 +992,7 @@ h5_read(h5::group parent, string const& name, MPO & M)
     M = MPO(N);
     for(auto n : range1(N))
         {
-        M.ref(n) = h5_read<ITensor>(g,tfm::format("MPO[%d]",n));
+        M.ref(n) = h5_read<ITensor>(g,tinyformat::format("MPO[%d]",n));
         }
     M.leftLim(llim);
     M.rightLim(rlim);

--- a/itensor/mps/mpo.cc
+++ b/itensor/mps/mpo.cc
@@ -976,7 +976,7 @@ h5_write(h5::group parent, string const& name, MPO const& M)
     h5_write(g,"llim",long(M.leftLim()));
     for(auto n : range1(M.length()))
         {
-        h5_write(g,format("MPO[%d]",n),M(n));
+        h5_write(g,tfm::format("MPO[%d]",n),M(n));
         }
     }
 
@@ -992,7 +992,7 @@ h5_read(h5::group parent, string const& name, MPO & M)
     M = MPO(N);
     for(auto n : range1(N))
         {
-        M.ref(n) = h5_read<ITensor>(g,format("MPO[%d]",n));
+        M.ref(n) = h5_read<ITensor>(g,tfm::format("MPO[%d]",n));
         }
     M.leftLim(llim);
     M.rightLim(rlim);

--- a/itensor/mps/mpoalgs.cc
+++ b/itensor/mps/mpoalgs.cc
@@ -250,7 +250,7 @@ densityMatrixApplyMPOImpl(MPO const& K,
         E[j] = E[j-1]*psi(j)*K(j)*dag(Kc(j))*dag(psic(j));
         if(dowrite)
             {
-            writeToFile(tfm::format("%s/E_%03d",writedir_,j-1),E[j-1]);
+            writeToFile(tinyformat::format("%s/E_%03d",writedir_,j-1),E[j-1]);
             E[j-1] = ITensor();
             }
         }
@@ -273,7 +273,7 @@ densityMatrixApplyMPOImpl(MPO const& K,
 
     for(int j = N-1; j > 1; --j)
         {
-        if(dowrite) readFromFile(tfm::format("%s/E_%03d",writedir_,j-1),E[j-1]);
+        if(dowrite) readFromFile(tinyformat::format("%s/E_%03d",writedir_,j-1),E[j-1]);
         if(not maxdim_set)
             {
             //Infer maxdim from bond dim of original MPS
@@ -455,7 +455,7 @@ fitApplyMPOImpl(Real fac,
             }
         else
             {
-            Error(tfm::format("NCenterSites = %d not supported",NCenterSites));
+            Error(tinyformat::format("NCenterSites = %d not supported",NCenterSites));
             }
         }
     Kx.dag();

--- a/itensor/mps/mpoalgs.cc
+++ b/itensor/mps/mpoalgs.cc
@@ -250,7 +250,7 @@ densityMatrixApplyMPOImpl(MPO const& K,
         E[j] = E[j-1]*psi(j)*K(j)*dag(Kc(j))*dag(psic(j));
         if(dowrite)
             {
-            writeToFile(format("%s/E_%03d",writedir_,j-1),E[j-1]);
+            writeToFile(tfm::format("%s/E_%03d",writedir_,j-1),E[j-1]);
             E[j-1] = ITensor();
             }
         }
@@ -273,7 +273,7 @@ densityMatrixApplyMPOImpl(MPO const& K,
 
     for(int j = N-1; j > 1; --j)
         {
-        if(dowrite) readFromFile(format("%s/E_%03d",writedir_,j-1),E[j-1]);
+        if(dowrite) readFromFile(tfm::format("%s/E_%03d",writedir_,j-1),E[j-1]);
         if(not maxdim_set)
             {
             //Infer maxdim from bond dim of original MPS
@@ -455,7 +455,7 @@ fitApplyMPOImpl(Real fac,
             }
         else
             {
-            Error(format("NCenterSites = %d not supported",NCenterSites));
+            Error(tfm::format("NCenterSites = %d not supported",NCenterSites));
             }
         }
     Kx.dag();

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -229,7 +229,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
     //Make N'th MPS tensor
     int chi = dim(s(N));
     chi = std::min(m,chi);
-    l[N-1] = Index(chi,tfm::format("Link,l=%d",N-1));
+    l[N-1] = Index(chi,tinyformat::format("Link,l=%d",N-1));
     auto O = randomOrthog(chi,dim(s(N)));
     M.ref(N) = matrixITensor(O,l[N-1],s(N));
 
@@ -239,7 +239,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
         auto prev_chi = chi;
         chi *= dim(s(j));
         chi = std::min(m,chi);
-        l[j-1] = Index(chi,tfm::format("Link,l=%d",j-1));
+        l[j-1] = Index(chi,tinyformat::format("Link,l=%d",j-1));
         O = randomOrthog(chi,prev_chi*dim(s(j)));
         auto [C,c] = combiner(s(j),l[j]);
         M.ref(j) = matrixITensor(O,l[j-1],c);
@@ -399,11 +399,11 @@ AFName(int j, string const& dirname) const
     { 
     if(dirname == "")
         {
-        return tfm::format("%s/A_%03d",writedir_,j);
+        return tinyformat::format("%s/A_%03d",writedir_,j);
         }
     else
         {
-        return tfm::format("%s/A_%03d",dirname,j);
+        return tinyformat::format("%s/A_%03d",dirname,j);
         }
     }
 
@@ -469,7 +469,7 @@ setBond(int b) const
     //if(b == 1)
         //{
         //writeToFile(writedir_+"/sites",*sites_);
-        //std::ofstream inf((tfm::format("%s/info")%writedir_).str().c_str());
+        //std::ofstream inf((tinyformat::format("%s/info")%writedir_).str().c_str());
         //    inf.write((char*) &l_orth_lim_,sizeof(l_orth_lim_));
         //    inf.write((char*) &r_orth_lim_,sizeof(r_orth_lim_));
         //    svd_.write(inf);
@@ -515,12 +515,12 @@ new_tensors(std::vector<ITensor>& A,
     auto a = std::vector<Index>(N+1);
     if(hasQNs(sites))
         {
-        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,tfm::format("Link,l=%d",i));
+        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,tinyformat::format("Link,l=%d",i));
         else Error("Cannot create QN conserving MPS with bond dimension greater than 1 from a SiteSet");
         }
     else
         {
-        for(auto i : range1(N)) a[i] = Index(m,tfm::format("Link,l=%d",i));
+        for(auto i : range1(N)) a[i] = Index(m,tinyformat::format("Link,l=%d",i));
         }
     A[1] = ITensor(sites(1),a[1]);
     for(int i = 2; i < N; i++)
@@ -539,12 +539,12 @@ new_tensors(std::vector<ITensor>& A,
     auto a = std::vector<Index>(N+1);
     if(hasQNs(sites))
         {
-        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,tfm::format("Link,l=%d",i));
+        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,tinyformat::format("Link,l=%d",i));
         else Error("Cannot create QN conserving MPS with bond dimension greater than 1 from an IndexSet");
         }
     else
         {
-        for(auto i : range1(N)) a[i] = Index(m,tfm::format("Link,l=%d",i));
+        for(auto i : range1(N)) a[i] = Index(m,tinyformat::format("Link,l=%d",i));
         }
     A[1] = ITensor(sites(1),a[1]);
     for(int i = 2; i < N; i++)
@@ -569,11 +569,11 @@ init_tensors(std::vector<ITensor>& A_, InitState const& initState)
             //Taking the divergence to be zero,solve for qa[i]
             qa[i] = Out*(-qa[i-1]*In - qn(initState(i)));
             }
-        for(auto i : range1(N_)) a[i] = Index(qa[i],1,tfm::format("Link,l=%d",i));
+        for(auto i : range1(N_)) a[i] = Index(qa[i],1,tinyformat::format("Link,l=%d",i));
         }
     else
         {
-        for(auto i : range1(N_)) a[i] = Index(1,tfm::format("Link,l=%d",i));
+        for(auto i : range1(N_)) a[i] = Index(1,tinyformat::format("Link,l=%d",i));
         }
 
     A_[1] = setElt(initState(1),a[1](1));
@@ -1787,7 +1787,7 @@ h5_write(h5::group parent, string const& name, MPS const& M)
     h5_write(g,"llim",long(M.leftLim()));
     for(auto n : range1(M.length()))
         {
-        h5_write(g,tfm::format("MPS[%d]",n),M(n));
+        h5_write(g,tinyformat::format("MPS[%d]",n),M(n));
         }
     }
 
@@ -1803,7 +1803,7 @@ h5_read(h5::group parent, string const& name, MPS & M)
     M = MPS(N);
     for(auto n : range1(N))
         {
-        M.ref(n) = h5_read<ITensor>(g,tfm::format("MPS[%d]",n));
+        M.ref(n) = h5_read<ITensor>(g,tinyformat::format("MPS[%d]",n));
         }
     M.leftLim(llim);
     M.rightLim(rlim);

--- a/itensor/mps/mps.cc
+++ b/itensor/mps/mps.cc
@@ -229,7 +229,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
     //Make N'th MPS tensor
     int chi = dim(s(N));
     chi = std::min(m,chi);
-    l[N-1] = Index(chi,format("Link,l=%d",N-1));
+    l[N-1] = Index(chi,tfm::format("Link,l=%d",N-1));
     auto O = randomOrthog(chi,dim(s(N)));
     M.ref(N) = matrixITensor(O,l[N-1],s(N));
 
@@ -239,7 +239,7 @@ randomCircuitMPS(SiteSet const& s, int m, Args const& args)
         auto prev_chi = chi;
         chi *= dim(s(j));
         chi = std::min(m,chi);
-        l[j-1] = Index(chi,format("Link,l=%d",j-1));
+        l[j-1] = Index(chi,tfm::format("Link,l=%d",j-1));
         O = randomOrthog(chi,prev_chi*dim(s(j)));
         auto [C,c] = combiner(s(j),l[j]);
         M.ref(j) = matrixITensor(O,l[j-1],c);
@@ -399,11 +399,11 @@ AFName(int j, string const& dirname) const
     { 
     if(dirname == "")
         {
-        return format("%s/A_%03d",writedir_,j);
+        return tfm::format("%s/A_%03d",writedir_,j);
         }
     else
         {
-        return format("%s/A_%03d",dirname,j);
+        return tfm::format("%s/A_%03d",dirname,j);
         }
     }
 
@@ -469,7 +469,7 @@ setBond(int b) const
     //if(b == 1)
         //{
         //writeToFile(writedir_+"/sites",*sites_);
-        //std::ofstream inf((format("%s/info")%writedir_).str().c_str());
+        //std::ofstream inf((tfm::format("%s/info")%writedir_).str().c_str());
         //    inf.write((char*) &l_orth_lim_,sizeof(l_orth_lim_));
         //    inf.write((char*) &r_orth_lim_,sizeof(r_orth_lim_));
         //    svd_.write(inf);
@@ -515,12 +515,12 @@ new_tensors(std::vector<ITensor>& A,
     auto a = std::vector<Index>(N+1);
     if(hasQNs(sites))
         {
-        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,format("Link,l=%d",i));
+        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,tfm::format("Link,l=%d",i));
         else Error("Cannot create QN conserving MPS with bond dimension greater than 1 from a SiteSet");
         }
     else
         {
-        for(auto i : range1(N)) a[i] = Index(m,format("Link,l=%d",i));
+        for(auto i : range1(N)) a[i] = Index(m,tfm::format("Link,l=%d",i));
         }
     A[1] = ITensor(sites(1),a[1]);
     for(int i = 2; i < N; i++)
@@ -539,12 +539,12 @@ new_tensors(std::vector<ITensor>& A,
     auto a = std::vector<Index>(N+1);
     if(hasQNs(sites))
         {
-        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,format("Link,l=%d",i));
+        if(m==1) for(auto i : range1(N)) a[i] = Index(QN(),m,tfm::format("Link,l=%d",i));
         else Error("Cannot create QN conserving MPS with bond dimension greater than 1 from an IndexSet");
         }
     else
         {
-        for(auto i : range1(N)) a[i] = Index(m,format("Link,l=%d",i));
+        for(auto i : range1(N)) a[i] = Index(m,tfm::format("Link,l=%d",i));
         }
     A[1] = ITensor(sites(1),a[1]);
     for(int i = 2; i < N; i++)
@@ -569,11 +569,11 @@ init_tensors(std::vector<ITensor>& A_, InitState const& initState)
             //Taking the divergence to be zero,solve for qa[i]
             qa[i] = Out*(-qa[i-1]*In - qn(initState(i)));
             }
-        for(auto i : range1(N_)) a[i] = Index(qa[i],1,format("Link,l=%d",i));
+        for(auto i : range1(N_)) a[i] = Index(qa[i],1,tfm::format("Link,l=%d",i));
         }
     else
         {
-        for(auto i : range1(N_)) a[i] = Index(1,format("Link,l=%d",i));
+        for(auto i : range1(N_)) a[i] = Index(1,tfm::format("Link,l=%d",i));
         }
 
     A_[1] = setElt(initState(1),a[1](1));
@@ -1787,7 +1787,7 @@ h5_write(h5::group parent, string const& name, MPS const& M)
     h5_write(g,"llim",long(M.leftLim()));
     for(auto n : range1(M.length()))
         {
-        h5_write(g,format("MPS[%d]",n),M(n));
+        h5_write(g,tfm::format("MPS[%d]",n),M(n));
         }
     }
 
@@ -1803,7 +1803,7 @@ h5_read(h5::group parent, string const& name, MPS & M)
     M = MPS(N);
     for(auto n : range1(N))
         {
-        M.ref(n) = h5_read<ITensor>(g,format("MPS[%d]",n));
+        M.ref(n) = h5_read<ITensor>(g,tfm::format("MPS[%d]",n));
         }
     M.leftLim(llim);
     M.rightLim(rlim);

--- a/itensor/mps/sites/customspin.h
+++ b/itensor/mps/sites/customspin.h
@@ -41,9 +41,9 @@ class CustomSpinSite
             error("Must pass named args \"2S\" (integer) or \"S\" (real number) to CustomSpin");
             }
 
-        if(DSmax < 1) error(tfm::format("Invalid spin value %d/2 in CustomSpin",DSmax));
+        if(DSmax < 1) error(tinyformat::format("Invalid spin value %d/2 in CustomSpin",DSmax));
 
-        auto tags = TagSet(tfm::format("Site,S=%d/2",DSmax));
+        auto tags = TagSet(tinyformat::format("Site,S=%d/2",DSmax));
         if(args.defined("SiteNumber") )
             {
             auto n = args.getInt("SiteNumber");

--- a/itensor/mps/sites/customspin.h
+++ b/itensor/mps/sites/customspin.h
@@ -41,9 +41,9 @@ class CustomSpinSite
             error("Must pass named args \"2S\" (integer) or \"S\" (real number) to CustomSpin");
             }
 
-        if(DSmax < 1) error(format("Invalid spin value %d/2 in CustomSpin",DSmax));
+        if(DSmax < 1) error(tfm::format("Invalid spin value %d/2 in CustomSpin",DSmax));
 
-        auto tags = TagSet(format("Site,S=%d/2",DSmax));
+        auto tags = TagSet(tfm::format("Site,S=%d/2",DSmax));
         if(args.defined("SiteNumber") )
             {
             auto n = args.getInt("SiteNumber");

--- a/itensor/mps/sites/spinone.h
+++ b/itensor/mps/sites/spinone.h
@@ -306,7 +306,7 @@ read(std::istream& s)
             I.read(s);
             if(dim(I) == 3) store.set(j,SpinOneSite(I));
             else if(dim(I) == 2) store.set(j,SpinHalfSite(I));
-            else throw ITError(tfm::format("SpinOne cannot read index of size %d",dim(I)));
+            else throw ITError(tinyformat::format("SpinOne cannot read index of size %d",dim(I)));
             }
         init(std::move(store));
         }

--- a/itensor/mps/sites/spinone.h
+++ b/itensor/mps/sites/spinone.h
@@ -306,7 +306,7 @@ read(std::istream& s)
             I.read(s);
             if(dim(I) == 3) store.set(j,SpinOneSite(I));
             else if(dim(I) == 2) store.set(j,SpinHalfSite(I));
-            else throw ITError(format("SpinOne cannot read index of size %d",dim(I)));
+            else throw ITError(tfm::format("SpinOne cannot read index of size %d",dim(I)));
             }
         init(std::move(store));
         }

--- a/itensor/mps/sites/spintwo.h
+++ b/itensor/mps/sites/spintwo.h
@@ -305,7 +305,7 @@ read(std::istream& s)
             I.read(s);
             if(dim(I) == 5) store.set(j,SpinTwoSite(I));
             else if(dim(I) == 2) store.set(j,SpinHalfSite(I));
-            else throw ITError(format("SpinTwo cannot read index of size %d",dim(I)));
+            else throw ITError(tfm::format("SpinTwo cannot read index of size %d",dim(I)));
             }
         init(std::move(store));
         }

--- a/itensor/mps/sites/spintwo.h
+++ b/itensor/mps/sites/spintwo.h
@@ -305,7 +305,7 @@ read(std::istream& s)
             I.read(s);
             if(dim(I) == 5) store.set(j,SpinTwoSite(I));
             else if(dim(I) == 2) store.set(j,SpinHalfSite(I));
-            else throw ITError(tfm::format("SpinTwo cannot read index of size %d",dim(I)));
+            else throw ITError(tinyformat::format("SpinTwo cannot read index of size %d",dim(I)));
             }
         init(std::move(store));
         }

--- a/itensor/mps/siteset.h
+++ b/itensor/mps/siteset.h
@@ -470,7 +470,7 @@ operator<<(std::ostream& s, SiteSet const& sites)
     s << "SiteSet:\n";
     for(int j = 1; j <= length(sites); ++j) 
         {
-        s << format("site %d = %s\n",j,sites(j));
+        s << tfm::format("site %d = %s\n",j,sites(j));
         }
     return s;
     }

--- a/itensor/mps/siteset.h
+++ b/itensor/mps/siteset.h
@@ -470,7 +470,7 @@ operator<<(std::ostream& s, SiteSet const& sites)
     s << "SiteSet:\n";
     for(int j = 1; j <= length(sites); ++j) 
         {
-        s << tfm::format("site %d = %s\n",j,sites(j));
+        s << tinyformat::format("site %d = %s\n",j,sites(j));
         }
     return s;
     }

--- a/itensor/mps/sweeps.h
+++ b/itensor/mps/sweeps.h
@@ -479,7 +479,7 @@ operator<<(std::ostream& s, const Sweeps& swps)
     s << "Sweeps:\n";
     for(int sw = 1; sw <= swps.nsweep(); ++sw)
         {
-        s << format("%d  MaxDim=%d, MinDim=%d, Cutoff=%.1E, Niter=%d, Noise=%.1E\n",
+        s << tfm::format("%d  MaxDim=%d, MinDim=%d, Cutoff=%.1E, Niter=%d, Noise=%.1E\n",
               sw,swps.maxdim(sw),swps.mindim(sw),swps.cutoff(sw),swps.niter(sw),swps.noise(sw));
         }
     return s;

--- a/itensor/mps/sweeps.h
+++ b/itensor/mps/sweeps.h
@@ -479,7 +479,7 @@ operator<<(std::ostream& s, const Sweeps& swps)
     s << "Sweeps:\n";
     for(int sw = 1; sw <= swps.nsweep(); ++sw)
         {
-        s << tfm::format("%d  MaxDim=%d, MinDim=%d, Cutoff=%.1E, Niter=%d, Noise=%.1E\n",
+        s << tinyformat::format("%d  MaxDim=%d, MinDim=%d, Cutoff=%.1E, Niter=%d, Noise=%.1E\n",
               sw,swps.maxdim(sw),swps.mindim(sw),swps.cutoff(sw),swps.niter(sw),swps.noise(sw));
         }
     return s;

--- a/itensor/spectrum.cc
+++ b/itensor/spectrum.cc
@@ -121,9 +121,9 @@ operator<<(std::ostream & s, Spectrum const& spec)
         s << "  Eigs kept:";
         for(auto j : range(stop))
             {
-            s << format(eigs(j) > 1E-3 ? (" %.3f") : (" %.3E"), eigs(j));
+            s << tfm::format(eigs(j) > 1E-3 ? (" %.3f") : (" %.3E"), eigs(j));
             }
-        s << format("\n  Trunc. error = %.3E\n", spec.truncerr());
+        s << tfm::format("\n  Trunc. error = %.3E\n", spec.truncerr());
         }
     return s;
     }

--- a/itensor/spectrum.cc
+++ b/itensor/spectrum.cc
@@ -121,9 +121,9 @@ operator<<(std::ostream & s, Spectrum const& spec)
         s << "  Eigs kept:";
         for(auto j : range(stop))
             {
-            s << tfm::format(eigs(j) > 1E-3 ? (" %.3f") : (" %.3E"), eigs(j));
+            s << tinyformat::format(eigs(j) > 1E-3 ? (" %.3f") : (" %.3E"), eigs(j));
             }
-        s << tfm::format("\n  Trunc. error = %.3E\n", spec.truncerr());
+        s << tinyformat::format("\n  Trunc. error = %.3E\n", spec.truncerr());
         }
     return s;
     }

--- a/itensor/tensor/mat.h
+++ b/itensor/tensor/mat.h
@@ -200,7 +200,7 @@ resize(MatRefc<T> const& M, size_t nr, size_t nc)
     {
     if((nrows(M)!=nr) || (ncols(M)!=nc))
         {
-        auto msg = format("Matrix ref has wrong size, expected=%dx%d, actual=%dx%d",
+        auto msg = tfm::format("Matrix ref has wrong size, expected=%dx%d, actual=%dx%d",
                           nr,nc,nrows(M),ncols(M));
         throw std::runtime_error(msg);
         }

--- a/itensor/tensor/mat.h
+++ b/itensor/tensor/mat.h
@@ -200,7 +200,7 @@ resize(MatRefc<T> const& M, size_t nr, size_t nc)
     {
     if((nrows(M)!=nr) || (ncols(M)!=nc))
         {
-        auto msg = tfm::format("Matrix ref has wrong size, expected=%dx%d, actual=%dx%d",
+        auto msg = tinyformat::format("Matrix ref has wrong size, expected=%dx%d, actual=%dx%d",
                           nr,nc,nrows(M),ncols(M));
         throw std::runtime_error(msg);
         }

--- a/itensor/tensor/range.h
+++ b/itensor/tensor/range.h
@@ -483,7 +483,7 @@ offset(Range_ const& r, size_t i1, Inds... inds)
     {
 #ifdef DEBUG
     if(1+sizeof...(inds) != order(r)) 
-        throw std::runtime_error(format("Wrong number of indices passed to TenRef (expected %d got %d)",order(r),1+sizeof...(inds)));
+        throw std::runtime_error(tfm::format("Wrong number of indices passed to TenRef (expected %d got %d)",order(r),1+sizeof...(inds)));
 #endif
     auto ia = stdx::make_array(i1,inds...);
     return detail::offsetImpl(stdx::select_overload{},r,ia);

--- a/itensor/tensor/range.h
+++ b/itensor/tensor/range.h
@@ -483,7 +483,7 @@ offset(Range_ const& r, size_t i1, Inds... inds)
     {
 #ifdef DEBUG
     if(1+sizeof...(inds) != order(r)) 
-        throw std::runtime_error(tfm::format("Wrong number of indices passed to TenRef (expected %d got %d)",order(r),1+sizeof...(inds)));
+        throw std::runtime_error(tinyformat::format("Wrong number of indices passed to TenRef (expected %d got %d)",order(r),1+sizeof...(inds)));
 #endif
     auto ia = stdx::make_array(i1,inds...);
     return detail::offsetImpl(stdx::select_overload{},r,ia);

--- a/itensor/tensor/rangeiter.h
+++ b/itensor/tensor/rangeiter.h
@@ -144,7 +144,7 @@ operator<<(std::ostream & s,
            RangeIter<R> const& it)
     {
     auto r = it.range().order();
-    s << format("%*d",3,it.offset()) << " (";
+    s << tfm::format("%*d",3,it.offset()) << " (";
     for(decltype(r) j = 0; j < r; ++j)
         {
         s << it[j];

--- a/itensor/tensor/rangeiter.h
+++ b/itensor/tensor/rangeiter.h
@@ -144,7 +144,7 @@ operator<<(std::ostream & s,
            RangeIter<R> const& it)
     {
     auto r = it.range().order();
-    s << tfm::format("%*d",3,it.offset()) << " (";
+    s << tinyformat::format("%*d",3,it.offset()) << " (";
     for(decltype(r) j = 0; j < r; ++j)
         {
         s << it[j];

--- a/itensor/tensor/ten_impl.h
+++ b/itensor/tensor/ten_impl.h
@@ -94,13 +94,13 @@ checkCompatible(TenRefc<R1,T1> const& A,
                 TenRefc<R2,T2> const& B,
                 std::string methodName = "")
     {
-    auto methodstr = (methodName != "" ? format("in %s",methodName) : "");
-    if(A.order() != B.order()) Error(format("Mismatched tensor orders %s",methodstr));
+    auto methodstr = (methodName != "" ? tfm::format("in %s",methodName) : "");
+    if(A.order() != B.order()) Error(tfm::format("Mismatched tensor orders %s",methodstr));
     for(decltype(A.order()) n = 0; n < A.order(); ++n)
         if(A.extent(n) != B.extent(n))
             {
             printfln("A.extent(%d)=%d  B.extent(%d)=%d",n,A.extent(n),n,B.extent(n));
-            Error(format("Mismatched tensor extent %s",methodstr));
+            Error(tfm::format("Mismatched tensor extent %s",methodstr));
             }
     }
 

--- a/itensor/tensor/ten_impl.h
+++ b/itensor/tensor/ten_impl.h
@@ -94,13 +94,13 @@ checkCompatible(TenRefc<R1,T1> const& A,
                 TenRefc<R2,T2> const& B,
                 std::string methodName = "")
     {
-    auto methodstr = (methodName != "" ? tfm::format("in %s",methodName) : "");
-    if(A.order() != B.order()) Error(tfm::format("Mismatched tensor orders %s",methodstr));
+    auto methodstr = (methodName != "" ? tinyformat::format("in %s",methodName) : "");
+    if(A.order() != B.order()) Error(tinyformat::format("Mismatched tensor orders %s",methodstr));
     for(decltype(A.order()) n = 0; n < A.order(); ++n)
         if(A.extent(n) != B.extent(n))
             {
             printfln("A.extent(%d)=%d  B.extent(%d)=%d",n,A.extent(n),n,B.extent(n));
-            Error(tfm::format("Mismatched tensor extent %s",methodstr));
+            Error(tinyformat::format("Mismatched tensor extent %s",methodstr));
             }
     }
 

--- a/itensor/tensor/vec.h
+++ b/itensor/tensor/vec.h
@@ -224,7 +224,7 @@ resize(VecRefc<T> const& v, size_t newsize)
     {
     if(v.size() != newsize)
         {
-        auto msg = tfm::format("Vector ref has wrong size, expected=%d, actual=%d",newsize,v.size());
+        auto msg = tinyformat::format("Vector ref has wrong size, expected=%d, actual=%d",newsize,v.size());
         throw std::runtime_error(msg);
         }
     }

--- a/itensor/tensor/vec.h
+++ b/itensor/tensor/vec.h
@@ -224,7 +224,7 @@ resize(VecRefc<T> const& v, size_t newsize)
     {
     if(v.size() != newsize)
         {
-        auto msg = format("Vector ref has wrong size, expected=%d, actual=%d",newsize,v.size());
+        auto msg = tfm::format("Vector ref has wrong size, expected=%d, actual=%d",newsize,v.size());
         throw std::runtime_error(msg);
         }
     }

--- a/itensor/types.h
+++ b/itensor/types.h
@@ -53,13 +53,13 @@ formatVal(double val)
     {
     if(val == 0.0 || val >= 1E-7)
         {
-        return tfm::format("%.7f",val);
+        return tinyformat::format("%.7f",val);
         }
     else if(val <= -1E-7)
         {
-        return tfm::format("%.6f",val);
+        return tinyformat::format("%.6f",val);
         }
-    return tfm::format("%.8E",val);
+    return tinyformat::format("%.8E",val);
     }
 
 std::string inline
@@ -69,11 +69,11 @@ formatVal(Cplx const& val)
     auto nrm = std::norm(val);
     if(nrm == 0. || nrm > 1E-10)
         {
-        return tfm::format("%f%s%fi",val.real(),sgn,std::fabs(val.imag()));
+        return tinyformat::format("%f%s%fi",val.real(),sgn,std::fabs(val.imag()));
         }
     else
         {
-        return tfm::format("%.8E%s%.8Ei",val.real(),sgn,std::fabs(val.imag()));
+        return tinyformat::format("%.8E%s%.8Ei",val.real(),sgn,std::fabs(val.imag()));
         }
     }
 

--- a/itensor/types.h
+++ b/itensor/types.h
@@ -53,13 +53,13 @@ formatVal(double val)
     {
     if(val == 0.0 || val >= 1E-7)
         {
-        return format("%.7f",val);
+        return tfm::format("%.7f",val);
         }
     else if(val <= -1E-7)
         {
-        return format("%.6f",val);
+        return tfm::format("%.6f",val);
         }
-    return format("%.8E",val);
+    return tfm::format("%.8E",val);
     }
 
 std::string inline
@@ -69,11 +69,11 @@ formatVal(Cplx const& val)
     auto nrm = std::norm(val);
     if(nrm == 0. || nrm > 1E-10)
         {
-        return format("%f%s%fi",val.real(),sgn,std::fabs(val.imag()));
+        return tfm::format("%f%s%fi",val.real(),sgn,std::fabs(val.imag()));
         }
     else
         {
-        return format("%.8E%s%.8Ei",val.real(),sgn,std::fabs(val.imag()));
+        return tfm::format("%.8E%s%.8Ei",val.real(),sgn,std::fabs(val.imag()));
         }
     }
 

--- a/itensor/util/print.h
+++ b/itensor/util/print.h
@@ -21,8 +21,6 @@
 
 namespace itensor {
 
-namespace tfm = tinyformat;
-
 template <typename... VArgs>
 void
 printf(const char* fmt_string, VArgs&&... vargs)
@@ -89,7 +87,7 @@ template <typename... VArgs>
 void
 printf(std::ostream & os, const char* fmt_string, VArgs&&... vargs)
     {
-    tfm::format(os,fmt_string,std::forward<VArgs>(vargs)...);
+    tinyformat::format(os,fmt_string,std::forward<VArgs>(vargs)...);
     std::cout.flush();
     }
 
@@ -97,7 +95,7 @@ template <typename... VArgs>
 void
 printfln(std::ostream & os, const char* fmt_string, VArgs&&... vargs)
     {
-    tfm::format(os,fmt_string,std::forward<VArgs>(vargs)...);
+    tinyformat::format(os,fmt_string,std::forward<VArgs>(vargs)...);
     os << std::endl;
     }
 
@@ -147,8 +145,8 @@ void
 PrintNice(const char* tok,
           T const& X)
     {
-    auto pre = tfm::format("%s = ",tok);
-    auto str = tfm::format("%s",X);
+    auto pre = tinyformat::format("%s = ",tok);
+    auto str = tinyformat::format("%s",X);
 
     //Put a newline after '=' if
     //output is large or output contains

--- a/itensor/util/print.h
+++ b/itensor/util/print.h
@@ -21,7 +21,7 @@
 
 namespace itensor {
 
-using tinyformat::format;
+namespace tfm = tinyformat;
 
 template <typename... VArgs>
 void
@@ -89,7 +89,7 @@ template <typename... VArgs>
 void
 printf(std::ostream & os, const char* fmt_string, VArgs&&... vargs)
     {
-    tinyformat::format(os,fmt_string,std::forward<VArgs>(vargs)...);
+    tfm::format(os,fmt_string,std::forward<VArgs>(vargs)...);
     std::cout.flush();
     }
 
@@ -97,7 +97,7 @@ template <typename... VArgs>
 void
 printfln(std::ostream & os, const char* fmt_string, VArgs&&... vargs)
     {
-    tinyformat::format(os,fmt_string,std::forward<VArgs>(vargs)...);
+    tfm::format(os,fmt_string,std::forward<VArgs>(vargs)...);
     os << std::endl;
     }
 
@@ -147,8 +147,8 @@ void
 PrintNice(const char* tok,
           T const& X)
     {
-    auto pre = format("%s = ",tok);
-    auto str = format("%s",X);
+    auto pre = tfm::format("%s = ",tok);
+    auto str = tfm::format("%s",X);
 
     //Put a newline after '=' if
     //output is large or output contains

--- a/itensor/util/safe_ptr.h
+++ b/itensor/util/safe_ptr.h
@@ -98,7 +98,7 @@ class SafePtr
         if(!validOffset())
             {
             auto error_msg = 
-            format("SafePtr: offset >= offset_end (%d >= %d)",
+            tfm::format("SafePtr: offset >= offset_end (%d >= %d)",
                    offset_,offset_end_);
             throw std::runtime_error(error_msg);
             }
@@ -106,7 +106,7 @@ class SafePtr
         if(expected_range > actual_range)
             {
             auto error_msg = 
-            format("SafePtr: expected_range > actual_range (%d > %d)",
+            tfm::format("SafePtr: expected_range > actual_range (%d > %d)",
                     expected_range,actual_range);
             throw std::runtime_error(error_msg);
             }
@@ -179,7 +179,7 @@ class SafePtr
         auto os = offset_+ind;
         if(os >= offset_end_)
             {
-            auto error_msg = format("SafePtr operator[](ind=%d): (offset+ind) >= offset_end (%d >= %d)",ind,os,offset_end_);
+            auto error_msg = tfm::format("SafePtr operator[](ind=%d): (offset+ind) >= offset_end (%d >= %d)",ind,os,offset_end_);
             throw std::runtime_error(error_msg);
             }
         return *(p_+os);
@@ -212,7 +212,7 @@ class SafePtr
         if(!validOffset())
             {
             auto error_msg = 
-            format("SafePtr: offset >= offset_end (%d >= %d)",
+            tfm::format("SafePtr: offset >= offset_end (%d >= %d)",
                    offset_,offset_end_);
             throw std::runtime_error(error_msg);
             }

--- a/itensor/util/safe_ptr.h
+++ b/itensor/util/safe_ptr.h
@@ -98,7 +98,7 @@ class SafePtr
         if(!validOffset())
             {
             auto error_msg = 
-            tfm::format("SafePtr: offset >= offset_end (%d >= %d)",
+            tinyformat::format("SafePtr: offset >= offset_end (%d >= %d)",
                    offset_,offset_end_);
             throw std::runtime_error(error_msg);
             }
@@ -106,7 +106,7 @@ class SafePtr
         if(expected_range > actual_range)
             {
             auto error_msg = 
-            tfm::format("SafePtr: expected_range > actual_range (%d > %d)",
+            tinyformat::format("SafePtr: expected_range > actual_range (%d > %d)",
                     expected_range,actual_range);
             throw std::runtime_error(error_msg);
             }
@@ -179,7 +179,7 @@ class SafePtr
         auto os = offset_+ind;
         if(os >= offset_end_)
             {
-            auto error_msg = tfm::format("SafePtr operator[](ind=%d): (offset+ind) >= offset_end (%d >= %d)",ind,os,offset_end_);
+            auto error_msg = tinyformat::format("SafePtr operator[](ind=%d): (offset+ind) >= offset_end (%d >= %d)",ind,os,offset_end_);
             throw std::runtime_error(error_msg);
             }
         return *(p_+os);
@@ -212,7 +212,7 @@ class SafePtr
         if(!validOffset())
             {
             auto error_msg = 
-            tfm::format("SafePtr: offset >= offset_end (%d >= %d)",
+            tinyformat::format("SafePtr: offset >= offset_end (%d >= %d)",
                    offset_,offset_end_);
             throw std::runtime_error(error_msg);
             }

--- a/itensor/util/tensorstats.h
+++ b/itensor/util/tensorstats.h
@@ -120,19 +120,19 @@ tstats(VArgs&&... vargs)
 inline std::ostream&
 operator<<(std::ostream& s, TStats const& T)
     {
-    s << format("A (%d) [ ",T.Ar);
+    s << tfm::format("A (%d) [ ",T.Ar);
     for(auto n : range(T.Ar)) s << T.Adims[n] << " ";
     s << "] { ";
     for(auto n : range(T.Ar)) s << T.Alabs[n] << " ";
     s << "}\n";
 
-    s << format("B (%d) [ ",T.Br);
+    s << tfm::format("B (%d) [ ",T.Br);
     for(auto n : range(T.Br)) s << T.Bdims[n] << " ";
     s << "] { ";
     for(auto n : range(T.Br)) s << T.Blabs[n] << " ";
     s << "}\n";
 
-    s << format("C (%d) [ ",T.Cr);
+    s << tfm::format("C (%d) [ ",T.Cr);
     for(auto n : range(T.Cr)) s << T.Cdims[n] << " ";
     s << "] { ";
     for(auto n : range(T.Cr)) s << T.Clabs[n] << " ";

--- a/itensor/util/tensorstats.h
+++ b/itensor/util/tensorstats.h
@@ -120,19 +120,19 @@ tstats(VArgs&&... vargs)
 inline std::ostream&
 operator<<(std::ostream& s, TStats const& T)
     {
-    s << tfm::format("A (%d) [ ",T.Ar);
+    s << tinyformat::format("A (%d) [ ",T.Ar);
     for(auto n : range(T.Ar)) s << T.Adims[n] << " ";
     s << "] { ";
     for(auto n : range(T.Ar)) s << T.Alabs[n] << " ";
     s << "}\n";
 
-    s << tfm::format("B (%d) [ ",T.Br);
+    s << tinyformat::format("B (%d) [ ",T.Br);
     for(auto n : range(T.Br)) s << T.Bdims[n] << " ";
     s << "] { ";
     for(auto n : range(T.Br)) s << T.Blabs[n] << " ";
     s << "}\n";
 
-    s << tfm::format("C (%d) [ ",T.Cr);
+    s << tinyformat::format("C (%d) [ ",T.Cr);
     for(auto n : range(T.Cr)) s << T.Cdims[n] << " ";
     s << "] { ";
     for(auto n : range(T.Cr)) s << T.Clabs[n] << " ";

--- a/itensor/util/timers.h
+++ b/itensor/util/timers.h
@@ -212,7 +212,7 @@ operator<<(std::ostream& s, Timers<NTimer> const& T)
     {
     auto tot = T.total();
     s << "-----------------------------------------------------\n";
-    s << format("Timers:                  Total Time = %.4f  %% Total",tot);
+    s << tfm::format("Timers:                  Total Time = %.4f  %% Total",tot);
     for(decltype(T.size()) n = 0; n < T.size(); ++n)
         {
         if(T.count(n) == 0) continue;
@@ -220,7 +220,7 @@ operator<<(std::ostream& s, Timers<NTimer> const& T)
         auto err = T.err(n);
         auto time = T.time(n);
         auto pct = 100*(time/tot);
-        s << format("\nSection %2d, Average = %.6f+-%.6f (%d), Total = %.4f [%5.1f%%]",n,avg,2.*err,T.count(n),time,pct);
+        s << tfm::format("\nSection %2d, Average = %.6f+-%.6f (%d), Total = %.4f [%5.1f%%]",n,avg,2.*err,T.count(n),time,pct);
         }
     s << "\n-----------------------------------------------------";
     return s;

--- a/itensor/util/timers.h
+++ b/itensor/util/timers.h
@@ -212,7 +212,7 @@ operator<<(std::ostream& s, Timers<NTimer> const& T)
     {
     auto tot = T.total();
     s << "-----------------------------------------------------\n";
-    s << tfm::format("Timers:                  Total Time = %.4f  %% Total",tot);
+    s << tinyformat::format("Timers:                  Total Time = %.4f  %% Total",tot);
     for(decltype(T.size()) n = 0; n < T.size(); ++n)
         {
         if(T.count(n) == 0) continue;
@@ -220,7 +220,7 @@ operator<<(std::ostream& s, Timers<NTimer> const& T)
         auto err = T.err(n);
         auto time = T.time(n);
         auto pct = 100*(time/tot);
-        s << tfm::format("\nSection %2d, Average = %.6f+-%.6f (%d), Total = %.4f [%5.1f%%]",n,avg,2.*err,T.count(n),time,pct);
+        s << tinyformat::format("\nSection %2d, Average = %.6f+-%.6f (%d), Total = %.4f [%5.1f%%]",n,avg,2.*err,T.count(n),time,pct);
         }
     s << "\n-----------------------------------------------------";
     return s;

--- a/itensor/util/tinyformat.h
+++ b/itensor/util/tinyformat.h
@@ -55,15 +55,15 @@
 // The strange types here emphasize the type safety of the interface; it is
 // possible to print a std::string using the "%s" conversion, and a
 // size_t using the "%d" conversion.  A similar result could be achieved
-// using either of the tfm::format() functions.  One prints on a user provided
+// using either of the tinyformat::format() functions.  One prints on a user provided
 // stream:
 //
-//   tfm::format(std::cerr, "%s, %s %d, %.2d:%.2d\n",
+//   tinyformat::format(std::cerr, "%s, %s %d, %.2d:%.2d\n",
 //               weekday, month, day, hour, min);
 //
 // The other returns a std::string:
 //
-//   std::string date = tfm::format("%s, %s %d, %.2d:%.2d\n",
+//   std::string date = tinyformat::format("%s, %s %d, %.2d:%.2d\n",
 //                                  weekday, month, day, hour, min);
 //   std::cout << date;
 //

--- a/sample/Heisenberg.h
+++ b/sample/Heisenberg.h
@@ -63,7 +63,7 @@ init_()
 
     for(int l = 0; l <= N_; ++l) 
         {
-        auto ts = tfm::format("Link,l=%d",l);
+        auto ts = tinyformat::format("Link,l=%d",l);
         links.at(l) = Index(QN({"Sz", 0}),3,
                             QN({"Sz",-2}),1,
                             QN({"Sz",+2}),1,

--- a/sample/Heisenberg.h
+++ b/sample/Heisenberg.h
@@ -63,7 +63,7 @@ init_()
 
     for(int l = 0; l <= N_; ++l) 
         {
-        auto ts = format("Link,l=%d",l);
+        auto ts = tfm::format("Link,l=%d",l);
         links.at(l) = Index(QN({"Sz", 0}),3,
                             QN({"Sz",-2}),1,
                             QN({"Sz",+2}),1,

--- a/unittest/ExpHeisenberg.h
+++ b/unittest/ExpHeisenberg.h
@@ -52,7 +52,7 @@ init_()
     auto links = std::vector<Index>(N_+1);
     for(int l = 0; l <= N_; ++l) 
         {
-        auto ts = format("Link,l=%d",l);
+        auto ts = tfm::format("Link,l=%d",l);
         links.at(l) = Index(QN({"Sz",0}),2,
                             QN({"Sz",-2}),1,
                             QN({"Sz",+2}),1,

--- a/unittest/ExpHeisenberg.h
+++ b/unittest/ExpHeisenberg.h
@@ -52,7 +52,7 @@ init_()
     auto links = std::vector<Index>(N_+1);
     for(int l = 0; l <= N_; ++l) 
         {
-        auto ts = tfm::format("Link,l=%d",l);
+        auto ts = tinyformat::format("Link,l=%d",l);
         links.at(l) = Index(QN({"Sz",0}),2,
                             QN({"Sz",-2}),1,
                             QN({"Sz",+2}),1,

--- a/unittest/ExpIsing.h
+++ b/unittest/ExpIsing.h
@@ -54,7 +54,7 @@ init_()
     auto links = std::vector<Index>(N_+1);
     for(int l = 0; l <= N_; ++l) 
         {
-        links.at(l) = Index(2,tfm::format("Link,l=%d",l));
+        links.at(l) = Index(2,tinyformat::format("Link,l=%d",l));
         }
 
     for(int n = 1; n <= N_; ++n)

--- a/unittest/ExpIsing.h
+++ b/unittest/ExpIsing.h
@@ -54,7 +54,7 @@ init_()
     auto links = std::vector<Index>(N_+1);
     for(int l = 0; l <= N_; ++l) 
         {
-        links.at(l) = Index(2,format("Link,l=%d",l));
+        links.at(l) = Index(2,tfm::format("Link,l=%d",l));
         }
 
     for(int n = 1; n <= N_; ++n)

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -362,7 +362,7 @@ SECTION("QDense Real Storage")
     CHECK(typeOf(nT) == Type::QDenseReal);
     CHECK(norm(T-nT) < 1E-12);
     }
-std::system(tfm::format("rm -f %s",fname).c_str());
+std::system(tinyformat::format("rm -f %s",fname).c_str());
 }
 
 SECTION("Set and Get Elements")

--- a/unittest/itensor_test.cc
+++ b/unittest/itensor_test.cc
@@ -362,7 +362,7 @@ SECTION("QDense Real Storage")
     CHECK(typeOf(nT) == Type::QDenseReal);
     CHECK(norm(T-nT) < 1E-12);
     }
-std::system(format("rm -f %s",fname).c_str());
+std::system(tfm::format("rm -f %s",fname).c_str());
 }
 
 SECTION("Set and Get Elements")

--- a/unittest/iterativesolvers_test.cc
+++ b/unittest/iterativesolvers_test.cc
@@ -70,7 +70,7 @@ SECTION("FourSite")
     //ITensor mpoh = H(2)*H(3);
     //ITensor phi2 = psi(2)*psi(3);
     //Real En2 = doDavidson(phi2,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << format("Energy from matrix Davidson (b=2) = %.20f")%En2 << endl;
+    //cout << tfm::format("Energy from matrix Davidson (b=2) = %.20f")%En2 << endl;
 
     //cout << endl << endl;
 
@@ -83,14 +83,14 @@ SECTION("FourSite")
     //PH.position(3,psi);
     //ITensor phi3 = psi(3) * psi(4);
     //Real En3 = d.davidson(PH,phi3);
-    //cout << format("Energy from tensor Davidson (b=3) = %.20f")%En3 << endl;
+    //cout << tfm::format("Energy from tensor Davidson (b=3) = %.20f")%En3 << endl;
 
     //cout << endl << endl;
 
     //mpoh = H(3)*H(4);
     //ITensor phi3m = psi(3)*psi(4);
     //Real En3m = doDavidson(phi3m,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << format("Energy from matrix Davidson (b=3) = %.20f")%En3m << endl;
+    //cout << tfm::format("Energy from matrix Davidson (b=3) = %.20f")%En3m << endl;
 
     //cout << "---------------------------------------" << endl << endl;
 
@@ -99,14 +99,14 @@ SECTION("FourSite")
     //PH.position(2,psi);
     //ITensor phi4 = psi(2) * psi(3);
     //Real En4 = d.davidson(PH,phi4);
-    //cout << format("Energy from tensor Davidson (b=2) = %.20f")%En4 << endl;
+    //cout << tfm::format("Energy from tensor Davidson (b=2) = %.20f")%En4 << endl;
 
     //cout << endl << endl;
 
     //mpoh = H(2)*H(3);
     //ITensor phi4m = psi(2)*psi(3);
     //Real En4m = doDavidson(phi4m,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << format("Energy from matrix Davidson (b=2) = %.20f")%En4m << endl;
+    //cout << tfm::format("Energy from matrix Davidson (b=2) = %.20f")%En4m << endl;
 
     //cout << "---------------------------------------" << endl << endl;
 
@@ -118,7 +118,7 @@ SECTION("FourSite")
     //mpoh = H(1)*H(2);
     //ITensor phi5 = psi(1) * psi(2);
     //Real En5 = doDavidson(phi5,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << format("Energy from matrix Davidson (b=1) = %.20f")%En5 << endl;
+    //cout << tfm::format("Energy from matrix Davidson (b=1) = %.20f")%En5 << endl;
 
     //cout << endl << endl;
 
@@ -133,7 +133,7 @@ SECTION("FourSite")
     ////ITensor AB; PH.product(phi6,AB);
     ////Print(Dot(phi6,AB));
     //Real En6 = d.davidson(PH,phi6);
-    //cout << format("Energy from tensor Davidson (b=1) = %.20f")%En6 << endl;
+    //cout << tfm::format("Energy from tensor Davidson (b=1) = %.20f")%En6 << endl;
 
     }
 
@@ -159,7 +159,7 @@ SECTION("IQFourSite")
     ITensor phi1 = psi(2) * psi(3);
 
     Real En1 = davidson(PH,phi1,"MaxIter=9");
-    //cout << format("Energy from tensor Davidson (b=2) = %.20f")%En1 << endl;
+    //cout << tfm::format("Energy from tensor Davidson (b=2) = %.20f")%En1 << endl;
     CHECK_CLOSE(En1,-0.95710678118);
 
 

--- a/unittest/iterativesolvers_test.cc
+++ b/unittest/iterativesolvers_test.cc
@@ -70,7 +70,7 @@ SECTION("FourSite")
     //ITensor mpoh = H(2)*H(3);
     //ITensor phi2 = psi(2)*psi(3);
     //Real En2 = doDavidson(phi2,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << tfm::format("Energy from matrix Davidson (b=2) = %.20f")%En2 << endl;
+    //cout << tinyformat::format("Energy from matrix Davidson (b=2) = %.20f")%En2 << endl;
 
     //cout << endl << endl;
 
@@ -83,14 +83,14 @@ SECTION("FourSite")
     //PH.position(3,psi);
     //ITensor phi3 = psi(3) * psi(4);
     //Real En3 = d.davidson(PH,phi3);
-    //cout << tfm::format("Energy from tensor Davidson (b=3) = %.20f")%En3 << endl;
+    //cout << tinyformat::format("Energy from tensor Davidson (b=3) = %.20f")%En3 << endl;
 
     //cout << endl << endl;
 
     //mpoh = H(3)*H(4);
     //ITensor phi3m = psi(3)*psi(4);
     //Real En3m = doDavidson(phi3m,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << tfm::format("Energy from matrix Davidson (b=3) = %.20f")%En3m << endl;
+    //cout << tinyformat::format("Energy from matrix Davidson (b=3) = %.20f")%En3m << endl;
 
     //cout << "---------------------------------------" << endl << endl;
 
@@ -99,14 +99,14 @@ SECTION("FourSite")
     //PH.position(2,psi);
     //ITensor phi4 = psi(2) * psi(3);
     //Real En4 = d.davidson(PH,phi4);
-    //cout << tfm::format("Energy from tensor Davidson (b=2) = %.20f")%En4 << endl;
+    //cout << tinyformat::format("Energy from tensor Davidson (b=2) = %.20f")%En4 << endl;
 
     //cout << endl << endl;
 
     //mpoh = H(2)*H(3);
     //ITensor phi4m = psi(2)*psi(3);
     //Real En4m = doDavidson(phi4m,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << tfm::format("Energy from matrix Davidson (b=2) = %.20f")%En4m << endl;
+    //cout << tinyformat::format("Energy from matrix Davidson (b=2) = %.20f")%En4m << endl;
 
     //cout << "---------------------------------------" << endl << endl;
 
@@ -118,7 +118,7 @@ SECTION("FourSite")
     //mpoh = H(1)*H(2);
     //ITensor phi5 = psi(1) * psi(2);
     //Real En5 = doDavidson(phi5,mpoh,PH.L(),PH.R(),9,2,1E-4);
-    //cout << tfm::format("Energy from matrix Davidson (b=1) = %.20f")%En5 << endl;
+    //cout << tinyformat::format("Energy from matrix Davidson (b=1) = %.20f")%En5 << endl;
 
     //cout << endl << endl;
 
@@ -133,7 +133,7 @@ SECTION("FourSite")
     ////ITensor AB; PH.product(phi6,AB);
     ////Print(Dot(phi6,AB));
     //Real En6 = d.davidson(PH,phi6);
-    //cout << tfm::format("Energy from tensor Davidson (b=1) = %.20f")%En6 << endl;
+    //cout << tinyformat::format("Energy from tensor Davidson (b=1) = %.20f")%En6 << endl;
 
     }
 
@@ -159,7 +159,7 @@ SECTION("IQFourSite")
     ITensor phi1 = psi(2) * psi(3);
 
     Real En1 = davidson(PH,phi1,"MaxIter=9");
-    //cout << tfm::format("Energy from tensor Davidson (b=2) = %.20f")%En1 << endl;
+    //cout << tinyformat::format("Energy from tensor Davidson (b=2) = %.20f")%En1 << endl;
     CHECK_CLOSE(En1,-0.95710678118);
 
 

--- a/unittest/mpo_test.cc
+++ b/unittest/mpo_test.cc
@@ -57,7 +57,7 @@ SECTION("Add MPOs")
         auto ll = vector<Index>(N);
         for(auto n : range1(N-1))
             {
-            auto ts = format("%s,l=%d",name,n);
+            auto ts = tfm::format("%s,l=%d",name,n);
             ll.at(n) = Index(QN({"Sz",-1},{"Nf",-1,-1}),2,
                              QN({"Sz",-1},{"Nf",+1,-1}),2,
                              QN({"Sz",-1},{"Nf=",0,-1}),2,
@@ -447,7 +447,7 @@ SECTION("Remove QNs from MPO")
         auto ll = vector<Index>(N);
         for(auto n : range1(N-1))
             {
-            auto ts = format("%s,l=%d",name,n);
+            auto ts = tfm::format("%s,l=%d",name,n);
             ll.at(n) = Index(QN({"Sz",-1},{"Nf",-1,-1}),2,
                              QN({"Sz",-1},{"Nf",+1,-1}),2,
                              QN({"Sz",-1},{"Nf",0,-1}),2,

--- a/unittest/mpo_test.cc
+++ b/unittest/mpo_test.cc
@@ -25,7 +25,7 @@ SECTION("Orthogonalize")
     //Make a random MPO of bond dim. m
     auto links = vector<Index>(N+1);
     for(auto n : range1(N))
-        links[n] = Index(d,format("MyLink,l=%d",n));
+        links[n] = Index(d,tfm::format("MyLink,l=%d",n));
     W.ref(1) = randomITensorC(links[1],sites(1),prime(sites(1)));
     for(auto n : range1(2,N-1))
         W.ref(n) = randomITensorC(links[n-1],sites(n),prime(sites(n)),links[n]);

--- a/unittest/mpo_test.cc
+++ b/unittest/mpo_test.cc
@@ -25,7 +25,7 @@ SECTION("Orthogonalize")
     //Make a random MPO of bond dim. m
     auto links = vector<Index>(N+1);
     for(auto n : range1(N))
-        links[n] = Index(d,tfm::format("MyLink,l=%d",n));
+        links[n] = Index(d,tinyformat::format("MyLink,l=%d",n));
     W.ref(1) = randomITensorC(links[1],sites(1),prime(sites(1)));
     for(auto n : range1(2,N-1))
         W.ref(n) = randomITensorC(links[n-1],sites(n),prime(sites(n)),links[n]);
@@ -57,7 +57,7 @@ SECTION("Add MPOs")
         auto ll = vector<Index>(N);
         for(auto n : range1(N-1))
             {
-            auto ts = tfm::format("%s,l=%d",name,n);
+            auto ts = tinyformat::format("%s,l=%d",name,n);
             ll.at(n) = Index(QN({"Sz",-1},{"Nf",-1,-1}),2,
                              QN({"Sz",-1},{"Nf",+1,-1}),2,
                              QN({"Sz",-1},{"Nf=",0,-1}),2,
@@ -447,7 +447,7 @@ SECTION("Remove QNs from MPO")
         auto ll = vector<Index>(N);
         for(auto n : range1(N-1))
             {
-            auto ts = tfm::format("%s,l=%d",name,n);
+            auto ts = tinyformat::format("%s,l=%d",name,n);
             ll.at(n) = Index(QN({"Sz",-1},{"Nf",-1,-1}),2,
                              QN({"Sz",-1},{"Nf",+1,-1}),2,
                              QN({"Sz",-1},{"Nf",0,-1}),2,


### PR DESCRIPTION
Trying to address #418.

The unfortunate part is that this relies on not introducing `format` from `tinyformat` into the namespace, so it would break user code that depends on just being able to directly use `format`.

I couldn't reproduce the original issue locally, @Wentzell could you see if this fixes the issue you saw? If it does then we can try to think of a safer fix.